### PR TITLE
Add text input component and stories

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,7 @@ module.exports = {
     '@typescript-eslint/prefer-enum-initializers': 'off',
     '@typescript-eslint/prefer-readonly-parameter-types': 'off',
     '@typescript-eslint/prefer-regexp-exec': 'off',
+    '@typescript-eslint/no-type-alias': 'off',
     '@typescript-eslint/no-magic-numbers': [
       'error',
       {
@@ -83,6 +84,7 @@ module.exports = {
     '@typescript-eslint/no-restricted-imports': 'off',
     'import/no-deprecated': 'error',
     'import/order': 'off',
+    'import/prefer-default-export': 'off',
     'import/no-extraneous-dependencies': [
       'error',
       {
@@ -111,18 +113,15 @@ module.exports = {
     'react/sort-comp': 'off',
     'react/state-in-constructor': 'off',
     'react/static-property-placement': 'off',
+    'react/prop-types': 'off',
+    'react/require-default-props': 'off',
     'react/boolean-prop-naming': [
       'error',
       {
         validateNested: true
       }
     ],
-    'react/function-component-definition': [
-      'error',
-      {
-        namedComponents: 'function-declaration'
-      }
-    ],
+    'react/function-component-definition': 'off',
     'react/no-unstable-nested-components': 'error',
     'react/jsx-handler-names': [
       'error',
@@ -145,14 +144,10 @@ module.exports = {
       }
     ],
     'react/jsx-no-constructed-context-values': 'error',
-    'react/jsx-props-no-spreading': [
-      'error',
-      {
-        html: 'ignore'
-      }
-    ],
+    'react/jsx-props-no-spreading': 'off',
     'react/jsx-no-script-url': 'error',
     'react/jsx-no-useless-fragment': 'error',
+    'unicorn/no-keyword-prefix': 'off',
     'unicorn/filename-case': [
       'error',
       {

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,8 @@ module.exports = {
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
-    '@storybook/addon-interactions'
+    '@storybook/addon-interactions',
+    '@storybook/addon-a11y'
   ],
   framework: '@storybook/react',
   core: {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@nabla/vite-plugin-eslint": "1.4.1",
+    "@storybook/addon-a11y": "^6.5.16",
     "@storybook/addon-actions": "^6.5.16",
     "@storybook/addon-essentials": "^6.5.16",
     "@storybook/addon-interactions": "^6.5.16",

--- a/src/components/TextInput.stories.tsx
+++ b/src/components/TextInput.stories.tsx
@@ -1,0 +1,32 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { TextInput } from './TextInput';
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  title: 'Components/TextInput',
+  component: TextInput,
+  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
+  argTypes: {
+    width: { control: 'select' },
+    isDisabled: { control: 'boolean' }
+  }
+} as ComponentMeta<typeof TextInput>;
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Template: ComponentStory<typeof TextInput> = arguments_ => (
+  <TextInput {...arguments_} />
+);
+
+export const Default = Template.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+Default.args = {
+  placeholder: 'Placeholder text',
+  width: 'default'
+};
+
+export const FullWidth = Template.bind({});
+FullWidth.args = {
+  ...Default.args,
+  width: 'full'
+};

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,0 +1,99 @@
+type TextInputReference =
+  | React.RefObject<HTMLInputElement>
+  | string
+  | ((instance: HTMLInputElement | null) => void)
+  | null
+  | undefined;
+
+interface RequiredTextInputProperties {
+  id: string;
+  name: string;
+  type: 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
+}
+
+interface CustomTextInputProperties {
+  className?: string;
+  width?: 'default' | 'full';
+  isDisabled?: boolean;
+  inputRef?: TextInputReference;
+  inputProps?: JSX.IntrinsicElements['input'];
+}
+
+export type OptionalTextInputProperties = CustomTextInputProperties &
+  JSX.IntrinsicElements['input'];
+
+export type TextInputProperties = OptionalTextInputProperties &
+  RequiredTextInputProperties;
+
+const baseStyles = [
+  'text-black',
+  'placeholder-gray',
+  'py-1',
+  'px-2',
+  'border',
+  'border-gray-60'
+];
+
+const hoverStyles = [
+  'hover:border-pacific',
+  'hover:outline-1',
+  'hover:outline-pacific',
+  'hover:outline'
+];
+
+const focusStyles = [
+  'focus:border-pacific',
+  'focus:outline-1',
+  'focus:outline-pacific',
+  'focus:outline-dotted',
+  'focus:outline-offset-2',
+  'focus:shadow-glow'
+];
+
+const widthStyles = {
+  default: [],
+  full: ['w-full']
+};
+
+const disabledStyles = [
+  'disabled:bg-gray-20',
+  'disabled:text-gray',
+  'disabled:cursor-not-allowed',
+  'disabled:outline-0',
+  'disabled:border-gray-60'
+];
+
+export function TextInput({
+  id,
+  name,
+  type,
+  className,
+  width = 'default',
+  isDisabled = false,
+  inputRef,
+  ...inputProperties
+}: TextInputProperties): JSX.Element {
+  const styles = [
+    ...baseStyles,
+    ...hoverStyles,
+    ...focusStyles,
+    ...disabledStyles,
+    ...widthStyles[width]
+  ];
+  const classes = [className, ...styles].join(' ');
+
+  return (
+    <input
+      data-testid='textInput'
+      className={classes}
+      disabled={isDisabled}
+      id={id}
+      name={name}
+      type={type}
+      ref={inputRef}
+      {...inputProperties}
+    />
+  );
+}
+
+export default TextInput;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ const config = {
     colors: {
       transparent: 'transparent',
       current: 'currentColor',
-      black: colors.black,
+      black: '#101820',
       white: colors.white,
       green: {
         dark: '#1e9642',
@@ -68,6 +68,11 @@ const config = {
     },
     fontFamily: {
       sans: ['Avenir Next', 'Arial', 'sans-serif']
+    },
+    extend: {
+      boxShadow: {
+        glow: '0 0 0 1px #0072ce;'
+      }
     }
   },
   experimental: { optimizeUniversalDefaults: true },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,6 +1758,28 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.23.tgz#1c15b0d2b872d89cc0f47c7243eacb447df8b8bd"
   integrity sha512-VEB8ygeP42CFLWyAJhN5OklpxUliqdNEUcXb4xZ/CINqtYGTjL5ukluKdKzQ0iWdUxyQ7B0539PAUhHKrCNWSQ==
 
+"@storybook/addon-a11y@^6.5.16":
+  version "6.5.16"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-6.5.16.tgz#9288a6c1d111fa4ec501d213100ffff91757d3fc"
+  integrity sha512-/e9s34o+TmEhy+Q3/YzbRJ5AJ/Sy0gjZXlvsCrcRpiQLdt5JRbN8s+Lbn/FWxy8U1Tb1wlLYlqjJ+fYi5RrS3A==
+  dependencies:
+    "@storybook/addons" "6.5.16"
+    "@storybook/api" "6.5.16"
+    "@storybook/channels" "6.5.16"
+    "@storybook/client-logger" "6.5.16"
+    "@storybook/components" "6.5.16"
+    "@storybook/core-events" "6.5.16"
+    "@storybook/csf" "0.0.2--canary.4566f4d.1"
+    "@storybook/theming" "6.5.16"
+    axe-core "^4.2.0"
+    core-js "^3.8.2"
+    global "^4.4.0"
+    lodash "^4.17.21"
+    react-sizeme "^3.0.1"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-actions@6.5.16", "@storybook/addon-actions@^6.5.16":
   version "6.5.16"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.5.16.tgz#2d7679f64899bef165a338582cb928102a09e364"
@@ -4173,7 +4195,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.12.0.tgz#ce1c9d143389679e253b314241ea9aa5cec980d3"
   integrity sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==
 
-axe-core@^4.4.3:
+axe-core@^4.2.0, axe-core@^4.4.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.6.3.tgz#fc0db6fdb65cc7a80ccf85286d91d64ababa3ece"
   integrity sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==
@@ -4313,6 +4335,11 @@ base@^0.11.1:
     isobject "^3.0.1"
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
+
+batch-processor@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/batch-processor/-/batch-processor-1.0.0.tgz#75c95c32b748e0850d10c2b168f6bdbe9891ace8"
+  integrity sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -6043,6 +6070,13 @@ electron-to-chromium@^1.4.284:
   version "1.4.300"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.300.tgz#37097e9bcdef687fb98abb5184434bdb958dfcd9"
   integrity sha512-tHLIBkKaxvG6NnDWuLgeYrz+LTwAnApHm2R3KBNcRrFn0qLmTrqQeB4X4atfN6YJbkOOOSdRBeQ89OfFUelnEQ==
+
+element-resize-detector@^1.2.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.2.4.tgz#3e6c5982dd77508b5fa7e6d5c02170e26325c9b1"
+  integrity sha512-Fl5Ftk6WwXE0wqCgNoseKWndjzZlDCwuPTcoVZfCP9R3EHQF8qUtr3YUPNETegRBOKqQKPW3n4kiIWngGi8tKg==
+  dependencies:
+    batch-processor "1.0.0"
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -8329,6 +8363,13 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
+
 ip@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
@@ -9526,7 +9567,7 @@ longest@^2.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-2.0.1.tgz#781e183296aa94f6d4d916dc335d0d17aefa23f8"
   integrity sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -11504,6 +11545,16 @@ react-router@6.3.0:
   dependencies:
     history "^5.2.0"
 
+react-sizeme@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-3.0.2.tgz#4a2f167905ba8f8b8d932a9e35164e459f9020e4"
+  integrity sha512-xOIAOqqSSmKlKFJLO3inBQBdymzDuXx4iuwkNcJmC96jeiOg5ojByvL+g3MW9LPEsojLbC6pf68zOfobK8IPlw==
+  dependencies:
+    element-resize-detector "^1.2.2"
+    invariant "^2.2.4"
+    shallowequal "^1.1.0"
+    throttle-debounce "^3.0.1"
+
 react@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -12202,6 +12253,11 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
+
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -13081,6 +13137,11 @@ thenify-all@^1.0.0:
   integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
+
+throttle-debounce@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-3.0.1.tgz#32f94d84dfa894f786c9a1f290e7a645b6a19abb"
+  integrity sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==
 
 throttleit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Just an input. Based off the react-uswds [`TextInput`](https://github.com/trussworks/react-uswds/blob/3934ecd3db1b4ac58fa0fdbcdd5d34a4e6c09ddf/src/components/forms/TextInput/TextInput.tsx) implementation but with CFPB styles.

I also installed the storybook accessibility add-on that provides a tab with automated a11y tests. And I cleaned up the insanely opinionated eslint config file a bit.

## Testing

1. Pull down branch.
2. `yarn && yarn start`
3. Visit http://localhost:6006/?path=/story/components-textinput--default
4. It should behave similarly to our standard [single-line text inputs](https://cfpb.github.io/design-system/components/text-inputs).

## Screenshots

<img width="966" alt="image" src="https://user-images.githubusercontent.com/1060248/224435184-d366a0d6-b27a-4a71-806f-02923a851681.png">


## Context

See https://github.local/reg-tech/sbl-data-collection/issues/374
