### PR TITLE
[Fix][Component] Icon - dynamic asset import

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { useImportSvg } from '../hooks/useImportSvg';
+import { useIconSvg } from '../hooks/useIconSvg';
 
 interface IconProperties {
   name: string;
@@ -19,10 +19,10 @@ interface IconProperties {
  */
 export const Icon = ({ name, alt, withBg = false }: IconProperties) => {
   const shapeModifier = getShapeModifier(name, withBg);
-  const classes = ['cf-icon-svg', `cf-icon-svg__${name}${shapeModifier}`];
-  const iconPath = name && `../assets/icons/${name}${shapeModifier}.svg?raw`;
+  const fileName = `${name}${shapeModifier}`;
+  const classes = ['cf-icon-svg', `cf-icon-svg__${fileName}`];
 
-  const icon = useImportSvg(iconPath);
+  const icon = useIconSvg(fileName);
 
   if (!icon) return null;
 

--- a/src/hooks/useIconSvg.tsx
+++ b/src/hooks/useIconSvg.tsx
@@ -6,21 +6,21 @@ import { useEffect, useState } from 'react';
  * @param path URL to SVG file
  * @returns string | null
  */
-export const useImportSvg = (path: string) => {
+export const useIconSvg = (fileName: string) => {
   let [icon, setIcon] = useState(null);
 
   useEffect(() => {
     const importSvg = async () => {
-      if (!path) return null;
+      if (!fileName) return null;
 
-      const importedIcon = await import(path);
+      const importedIcon = await import(`../assets/icons/${fileName}.svg?raw`);
       if (!importedIcon || !importedIcon.default) return;
 
       setIcon(importedIcon.default);
     };
 
     importSvg();
-  }, [path, setIcon]);
+  }, [fileName, setIcon]);
 
   if (!icon) return null;
   return icon;


### PR DESCRIPTION
Puts the dynamic import path for the icons directly in the "import" statement.
 
Previously we saw that the icons, though displayed correctly when running locally, were not correctly bundled or displayed in the Netlify deployments.  
 
As shown in this [PR's preview deployment](https://deploy-preview-8--cfpb-design-stories.netlify.app/?path=/docs/components-icon--icon), the icons now display correctly. 