### PR TITLE
Add Expandable and Expandable.stories files

### DIFF
--- a/src/components/Expandable.stories.tsx
+++ b/src/components/Expandable.stories.tsx
@@ -1,0 +1,25 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import Expandable from './Expandable';
+
+export default {
+  title: 'Components/Expandable',
+  component: Expandable,
+
+  argTypes: {
+    openOnLoad: { control: 'select' }
+  }
+} as ComponentMeta<typeof Expandable>;
+
+const Template: ComponentStory<typeof Expandable> = arguments_ => (
+  // <div className='o-expandable'>
+  <Expandable {...arguments_} />
+  // </div>
+);
+
+export const Default = Template.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+Default.args = {
+  header: 'Expandable Header',
+  paragraphText: 'This is a paragraph',
+  expandableLink: 'this is a link'
+};

--- a/src/components/Expandable.tsx
+++ b/src/components/Expandable.tsx
@@ -1,0 +1,65 @@
+import { Icon } from './Icon';
+import { useState } from 'react';
+
+interface ExpandableProps {
+  header: string;
+  paragraphText: string;
+  expandableLink: string;
+  openOnLoad?: boolean;
+}
+
+const Expandable: React.FC<ExpandableProps> = ({
+  header,
+  paragraphText,
+  expandableLink
+}) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const toggleExpanded = () => setExpanded(!expanded);
+
+  return (
+    <div
+      className='o-expandable
+            o-expandable__padded
+            o-expandable__background
+            o-expandable__border'
+    >
+      <button
+        className='o-expandable_header o-expandable_target'
+        title='Expand content'
+        onClick={toggleExpanded}
+      >
+        <h3 className='h4 o-expandable_label'>{header}</h3>
+        <span className='o-expandable_link'>
+          <span
+            className={`o-expandable_cue o-expandable_cue-${
+              expanded ? 'close' : 'open'
+            }`}
+          >
+            <span className=''>{expanded ? 'Hide' : 'Show'}</span>
+
+            {expanded ? (
+              <Icon name='minus' alt={'minus'} withBg={true} />
+            ) : (
+              <Icon name='plus' alt={'plus'} withBg={true} />
+            )}
+          </span>
+        </span>
+      </button>
+      {expanded && (
+        <div
+          className={`o-expandable_content ${
+            expanded ? 'o-expandable_content__onload-open' : ''
+          }`}
+        >
+          <p>
+            {paragraphText}
+            <a href='#'>{expandableLink}</a>.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Expandable;


### PR DESCRIPTION
For expandable, I got the functionality of expanding and retracting working along with the associated texts but I can't get the words "show" or "hide" to appear along with their associated icons.