### PR TITLE
Banner (Global Eyebrow)

### DIFF
--- a/src/components/Banner.less
+++ b/src/components/Banner.less
@@ -1,0 +1,117 @@
+@gray-40: #b4b5b6;
+@gray-5: #f7f8f9;
+
+.m-global-eyebrow {
+  font-size: 0.75em;
+
+  .a-tagline {
+    align-items: center;
+  }
+
+  &_actions {
+    text-align: right;
+  }
+
+  &_languages {
+    display: inline;
+
+    .m-list_item:not(:last-child) {
+      margin-right: 0.6em;
+      margin-bottom: 0;
+
+      @media only all and (min-width: 992px) {
+        margin-right: 0.83em;
+      }
+    }
+
+    a {
+      border: none;
+    }
+  }
+
+  &_phone {
+    padding-left: 0.93em;
+  }
+
+  &__horizontal {
+    width: 100%;
+    display: inline-block;
+    padding-top: 0.625em;
+    padding-bottom: 0.625em;
+    background: @gray-5;
+    border-bottom: 1px solid @gray-40;
+
+    /* This is to allow vertical overlap with the languages */
+    .a-tagline {
+      float: left;
+    }
+
+    .m-global-eyebrow_languages {
+      text-align: right;
+    }
+
+    // Tablet/mobile sizes.
+    @media only all and (max-width: 56.25em) {
+      .m-global-eyebrow_actions {
+        display: none;
+      }
+
+      /* Prevent spacing issues since the languages aren't displayed */
+      .a-tagline {
+        float: none;
+      }
+    }
+  }
+
+  &__list {
+    padding-top: 0.9375em;
+    padding-left: 1.875em;
+    padding-right: 0.9375em;
+    padding-bottom: 1.875em;
+
+    .a-tagline {
+      display: none;
+    }
+
+    .m-global-eyebrow_actions {
+      padding: 0;
+      border: 0;
+      margin: 0;
+
+      text-align: left;
+    }
+
+    .m-global-eyebrow_phone,
+    .m-global-eyebrow_languages {
+      display: block;
+      padding-left: 0;
+    }
+
+    .m-global-eyebrow_phone {
+      border-top: 1px solid @gray-40;
+      padding-top: 0.9375em;
+
+      // Apply padding to the phone number to increase the touch area.
+      a {
+        padding-top: 0.9375em;
+        padding-bottom: 0.9375em;
+      }
+    }
+
+    .m-global-eyebrow_languages {
+      margin-bottom: 0.9375em;
+
+      .m-list_item {
+
+        // Apply padding to the language links to increase their touch area.
+        a {
+          display: block;
+          text-align: center;
+          min-width: 48px;
+          padding-top: 0.9375em;
+          padding-bottom: 0.9375em;
+        }
+      }
+    }
+  }
+}

--- a/src/components/Banner.less
+++ b/src/components/Banner.less
@@ -1,12 +1,7 @@
-@gray-40: #b4b5b6;
-@gray-5: #f7f8f9;
+@import (reference) '@cfpb/cfpb-design-system';
 
 .m-global-eyebrow {
-  font-size: 0.75em;
-
-  .a-tagline {
-    align-items: center;
-  }
+  font-size: unit((12px / @base-font-size-px), em);
 
   &_actions {
     text-align: right;
@@ -16,28 +11,28 @@
     display: inline;
 
     .m-list_item:not(:last-child) {
-      margin-right: 0.6em;
+      margin-right: unit((7px / 12px), em);
       margin-bottom: 0;
 
-      @media only all and (min-width: 992px) {
-        margin-right: 0.83em;
-      }
+      .respond-to-min(@bp-lg-min, {
+          margin-right: unit((10px / 12px), em);
+        });
     }
 
     a {
-      border: none;
+      .u-link__no-border();
     }
   }
 
   &_phone {
-    padding-left: 0.93em;
+    padding-left: unit((((@grid_gutter-width / 2)) / @base-font-size-px), em);
   }
 
   &__horizontal {
     width: 100%;
     display: inline-block;
-    padding-top: 0.625em;
-    padding-bottom: 0.625em;
+    padding-top: unit(((@grid_gutter-width / 3) / @base-font-size-px), em);
+    padding-bottom: unit(((@grid_gutter-width / 3) / @base-font-size-px), em);
     background: @gray-5;
     border-bottom: 1px solid @gray-40;
 
@@ -51,27 +46,22 @@
     }
 
     // Tablet/mobile sizes.
-    @media only all and (max-width: 56.25em) {
+    .respond-to-max(@bp-sm-max, {
       .m-global-eyebrow_actions {
         display: none;
-      }
-
       /* Prevent spacing issues since the languages aren't displayed */
-      .a-tagline {
-        float: none;
-      }
-    }
+        .a-tagline {
+            float: none;
+          }
+        }
+    });
   }
 
   &__list {
-    padding-top: 0.9375em;
-    padding-left: 1.875em;
-    padding-right: 0.9375em;
-    padding-bottom: 1.875em;
-
-    .a-tagline {
-      display: none;
-    }
+    padding-top: unit(((@grid_gutter-width / 2) / @base-font-size-px), rem);
+    padding-left: unit((@grid_gutter-width / @base-font-size-px), rem);
+    padding-right: unit(((@grid_gutter-width / 2) / @base-font-size-px), rem);
+    padding-bottom: unit((@grid_gutter-width / @base-font-size-px), rem);
 
     .m-global-eyebrow_actions {
       padding: 0;
@@ -89,27 +79,35 @@
 
     .m-global-eyebrow_phone {
       border-top: 1px solid @gray-40;
-      padding-top: 0.9375em;
+      padding-top: unit(((@grid_gutter-width / 2) / @base-font-size-px), rem);
 
       // Apply padding to the phone number to increase the touch area.
       a {
-        padding-top: 0.9375em;
-        padding-bottom: 0.9375em;
+        padding-top: unit(((@grid_gutter-width / 2) / @base-font-size-px), rem);
+        padding-bottom: unit(
+          ((@grid_gutter-width / 2) / @base-font-size-px),
+          rem
+        );
       }
     }
 
     .m-global-eyebrow_languages {
-      margin-bottom: 0.9375em;
+      margin-bottom: unit(((@grid_gutter-width / 2) / @base-font-size-px), rem);
 
       .m-list_item {
-
         // Apply padding to the language links to increase their touch area.
         a {
           display: block;
           text-align: center;
           min-width: 48px;
-          padding-top: 0.9375em;
-          padding-bottom: 0.9375em;
+          padding-top: unit(
+            ((@grid_gutter-width / 2) / @base-font-size-px),
+            rem
+          );
+          padding-bottom: unit(
+            ((@grid_gutter-width / 2) / @base-font-size-px),
+            rem
+          );
         }
       }
     }

--- a/src/components/Banner.stories.tsx
+++ b/src/components/Banner.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { SyntheticEvent } from 'react';
+import { Banner } from './Banner';
+import { AllLanguageCodes, LanguageLink } from './BannerLanguageLink';
+
+const meta: Meta<typeof Banner> = {
+  component: Banner,
+  argTypes: {}
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Helpers to avoid unnecessary navigation
+ */
+const onPreventInteraction = (error: SyntheticEvent): void => {
+  error.preventDefault();
+};
+const UnclickableLink = ({
+  children,
+  ...others
+}: {
+  children: JSX.Element | string;
+  [key: string]: JSX.Element | string;
+}): JSX.Element => (
+  // eslint-disable-next-line jsx-a11y/interactive-supports-focus
+  <span
+    role='link'
+    onClick={onPreventInteraction}
+    onKeyUp={onPreventInteraction}
+    {...others}
+  >
+    {children}
+  </span>
+);
+
+export const BannerWithLinks: Story = {
+  render: properties => <Banner {...properties} />,
+  args: {
+    links: [
+      <UnclickableLink key='Link 1'>
+        <a href='/link'>Link 1</a>
+      </UnclickableLink>,
+      <UnclickableLink key='Link 2'>
+        <a href='/link'>Link 2</a>
+      </UnclickableLink>,
+      <UnclickableLink key='Link 3'>
+        <a href='/link'>Link 3</a>
+      </UnclickableLink>
+    ]
+  }
+};
+
+export const CFGovEdition: Story = {
+  ...BannerWithLinks,
+  args: {
+    links: AllLanguageCodes.filter(code => code !== 'en').map(code => (
+      <UnclickableLink key={code}>
+        <LanguageLink code={code} />
+      </UnclickableLink>
+    )),
+    phoneNumber: '1-855-411-2372',
+    tagline: (
+      <>
+        An official website of the{' '}
+        <span className='u-nowrap'>United States government</span>
+      </>
+    )
+  }
+};

--- a/src/components/Banner.test.tsx
+++ b/src/components/Banner.test.tsx
@@ -1,0 +1,77 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { Banner } from './Banner';
+import { LanguageLink } from './BannerLanguageLink';
+
+describe('<Banner />', () => {
+  it('renders tagline correctly', () => {
+    render(
+      <Banner tagline='An official website of the United States government' />
+    );
+
+    expect(
+      screen.getByText('An official website of the United States government')
+    ).toBeInTheDocument();
+  });
+
+  it('renders phoneNumber correctly', () => {
+    // Formatting applied
+    render(<Banner phoneNumber='1-855-411-2372' />);
+    expect(screen.getByText('(855) 411-2372')).toBeInTheDocument();
+
+    // Formatting skipped
+    render(<Banner phoneNumber='855-411-2372' />);
+    expect(screen.getByText('855-411-2372')).toBeInTheDocument();
+  });
+
+  it('renders links correctly', () => {
+    render(
+      <Banner
+        links={[
+          <LanguageLink code='es' key='es' />,
+          <LanguageLink code='zh' key='zh' />,
+          <LanguageLink code='vi' key='vi' />,
+          <LanguageLink
+            code=':)'
+            key=':)'
+            href='/customLang'
+            label='Custom language'
+          />
+        ]}
+      />
+    );
+
+    const spanish = screen.getByText('Español');
+    const chinese = screen.getByText('中文');
+    const vietnamese = screen.getByText('Tiếng Việt');
+    const custom = screen.getByText('Custom language');
+
+    expect(spanish).toBeInTheDocument();
+    expect(spanish).toHaveAttribute('href', '/es/');
+    expect(spanish).toHaveAttribute('lang', 'es');
+    expect(spanish).toHaveAttribute('hrefLang', 'es');
+
+    expect(chinese).toBeInTheDocument();
+    expect(chinese).toHaveAttribute('href', '/language/zh/');
+    expect(chinese).toHaveAttribute('lang', 'zh');
+    expect(chinese).toHaveAttribute('hrefLang', 'zh');
+
+    expect(vietnamese).toBeInTheDocument();
+
+    expect(custom).toBeInTheDocument();
+    expect(custom).toHaveAttribute('href', '/customLang');
+    expect(custom).toHaveAttribute('hrefLang', ':)');
+    expect(custom).toHaveAttribute('lang', ':)');
+
+    expect(screen.queryByText('Tagalog')).not.toBeInTheDocument();
+  });
+
+  it('renders non-horizontal version', () => {
+    const taglineText = 'This should not be displayed';
+
+    render(<Banner isHorizontal={false} tagline={taglineText} />);
+
+    expect(screen.getByTestId('eyebrow')).toHaveClass('m-global-eyebrow__list');
+    expect(screen.queryByText(taglineText)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,0 +1,80 @@
+import classnames from 'classnames';
+import type { JSXElement } from '../types/jsxElement';
+import './Banner.less';
+import { Tagline } from './Tagline';
+
+interface BannerProperties {
+  isHorizontal?: boolean;
+  links?: JSX.Element[];
+  phoneNumber?: string;
+  tagline?: JSX.Element | string;
+}
+
+interface TelephoneLinkProperties {
+  phoneNumber: string;
+}
+
+const TelephoneLink = ({
+  phoneNumber
+}: TelephoneLinkProperties): JSXElement => {
+  if (/\d-\d{3}-\d{3}-\d{4}/.test(phoneNumber)) {
+    const [, areaCode, ...others] = phoneNumber.split('-');
+
+    return (
+      <a href={`tel:+${phoneNumber}`}>
+        ({areaCode}) {others.join('-')}
+      </a>
+    );
+  }
+
+  return <a href={`tel:+${phoneNumber}`}>{phoneNumber}</a>;
+};
+
+/**
+ * CFGov's Global Eyebrow component
+ */
+export const Banner = ({
+  isHorizontal = true,
+  tagline = 'This is a tagline',
+  phoneNumber,
+  links = []
+}: BannerProperties): JSX.Element => {
+  const eyebrowClasses = ['m-global-eyebrow'];
+  const wrapperClasses = ['wrapper'];
+  const linkListClasses = ['m-list'];
+  let taglineContent = null;
+
+  if (isHorizontal) {
+    eyebrowClasses.push('m-global-eyebrow__horizontal');
+    wrapperClasses.push('wrapper__match-content');
+    linkListClasses.push('m-list__horizontal m-global-eyebrow_languages');
+    taglineContent = <Tagline>{tagline}</Tagline>;
+  } else {
+    eyebrowClasses.push('m-global-eyebrow__list');
+  }
+
+  return (
+    <div className={classnames(eyebrowClasses)} data-testid='eyebrow'>
+      <div className={classnames(wrapperClasses)}>
+        {taglineContent}
+
+        <div className='m-global-eyebrow_actions'>
+          {links.length > 0 && (
+            <div className={classnames(linkListClasses)}>
+              {links.map(link => (
+                <li className='m-list_item' key={link.key}>
+                  {link}
+                </li>
+              ))}
+            </div>
+          )}
+          {phoneNumber ? (
+            <span className='m-global-eyebrow_phone'>
+              <TelephoneLink phoneNumber={phoneNumber} />
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -60,13 +60,13 @@ export const Banner = ({
 
         <div className='m-global-eyebrow_actions'>
           {links.length > 0 && (
-            <div className={classnames(linkListClasses)}>
+            <ul className={classnames(linkListClasses)}>
               {links.map(link => (
                 <li className='m-list_item' key={link.key}>
                   {link}
                 </li>
               ))}
-            </div>
+            </ul>
           )}
           {phoneNumber ? (
             <span className='m-global-eyebrow_phone'>

--- a/src/components/BannerLanguageLink.tsx
+++ b/src/components/BannerLanguageLink.tsx
@@ -1,0 +1,80 @@
+import type { JSXElement } from '../types/jsxElement';
+
+export type LanguageDefinition = Record<
+  string | symbol,
+  Record<string | symbol, string>
+>;
+
+export const LanguageMap: LanguageDefinition = {
+  en: { label: 'English', code: 'en', href: '/en/' },
+  es: { label: 'Español', code: 'es', href: '/es/' },
+  zh: { label: '中文', code: 'zh' },
+  vi: { label: 'Tiếng Việt', code: 'vi' },
+  ko: { label: '한국어', code: 'ko' },
+  tl: { label: 'Tagalog', code: 'tl' },
+  ru: { label: 'Pусский', code: 'ru' },
+  ar: { label: 'العربية', code: 'ar' },
+  ht: { label: 'Kreyòl Ayisyen', code: 'ht' }
+};
+
+export const AllLanguageCodes = [
+  'en',
+  'es',
+  'zh',
+  'vi',
+  'ko',
+  'tl',
+  'ru',
+  'ar',
+  'ht'
+];
+
+export interface LanguageLinkProperties {
+  code: string;
+  href?: string;
+  label?: string;
+  languageMap?: LanguageDefinition;
+}
+
+/**
+ * CFGov language link
+ *
+ * @param code Language code
+ * @param href URL
+ * @param label Display text
+ * @param languageMap A collection of language definitions
+ *
+ * @returns JSX.Element
+ */
+export const LanguageLink = ({
+  code,
+  href,
+  label,
+  languageMap = LanguageMap,
+  ...others
+}: LanguageLinkProperties): JSXElement => {
+  const config = languageMap[code];
+  let codeResolved = code;
+  let langResolved = code;
+  let labelResolved = label;
+  let hrefResolved = href;
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (config) {
+    codeResolved = config.code;
+    langResolved = config.code;
+    labelResolved = label ?? config.label;
+    hrefResolved = config.href || href;
+  }
+
+  return (
+    <a
+      href={hrefResolved ?? `/language/${codeResolved}/`}
+      hrefLang={codeResolved}
+      lang={langResolved}
+      {...others}
+    >
+      {labelResolved}
+    </a>
+  );
+};

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -12,6 +12,7 @@ import type {
   PropsValue
 } from 'react-select';
 import Select, { createFilter } from 'react-select';
+import type { JSXElement } from '../types/jsxElement';
 import { Icon } from './Icon';
 import { Label } from './Label';
 
@@ -114,7 +115,7 @@ const Pills = ({
   selected,
   isMulti,
   onChange
-}: PillsProperties): JSX.Element | null => {
+}: PillsProperties): JSXElement => {
   if (
     !isMulti ||
     !selected ||

--- a/src/components/Tagline.stories.tsx
+++ b/src/components/Tagline.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tagline } from './Tagline';
+
+const meta: Meta<typeof Tagline> = {
+  component: Tagline,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+### CFPB DS - Tagline component
+
+Source: https://cfpb.github.io/design-system/patterns/taglines
+`
+      }
+    }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const StandardTagline: Story = {
+  render: properties => (
+    <Tagline {...properties}>
+      <>
+        An official website of the{' '}
+        <span className='u-nowrap'>United States government</span>
+      </>
+    </Tagline>
+  )
+};
+
+export const LargeTagline: Story = {
+  ...StandardTagline,
+  args: { isLarge: true }
+};

--- a/src/components/Tagline.test.tsx
+++ b/src/components/Tagline.test.tsx
@@ -1,0 +1,20 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { Tagline } from './Tagline';
+
+describe('<Tagline />', () => {
+  it('renders tagline text correctly', () => {
+    render(<Tagline>Hoboken</Tagline>);
+    expect(screen.getByText('Hoboken')).toBeInTheDocument();
+  });
+
+  it('renders usa flag', () => {
+    render(<Tagline>tagline</Tagline>);
+    expect(screen.getByTestId('usa-flag')).toBeInTheDocument();
+  });
+
+  it('renders large version', () => {
+    render(<Tagline isLarge>tagline</Tagline>);
+    expect(screen.getByTestId('tagline')).toHaveClass('a-tagline__large');
+  });
+});

--- a/src/components/Tagline.tsx
+++ b/src/components/Tagline.tsx
@@ -1,0 +1,22 @@
+import classnames from 'classnames';
+import type { JSXElement } from '../types/jsxElement';
+
+interface TaglineProperties {
+  children: JSX.Element | string;
+  isLarge?: boolean;
+}
+
+export const Tagline = ({
+  isLarge = false,
+  children
+}: TaglineProperties): JSXElement => {
+  const baseClasses = ['a-tagline'];
+  if (isLarge) baseClasses.push('a-tagline__large');
+
+  return (
+    <div className={classnames(baseClasses)} data-testid='tagline'>
+      <span className='u-usa-flag' data-testid='usa-flag' />
+      <div className='a-tagline_text'>{children}</div>
+    </div>
+  );
+};

--- a/src/components/header.css
+++ b/src/components/header.css
@@ -1,4 +1,4 @@
-.wrapper {
+header .wrapper {
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   padding: 15px 20px;

--- a/src/components/header.css
+++ b/src/components/header.css
@@ -1,4 +1,4 @@
-header .wrapper {
+.wrapper {
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   padding: 15px 20px;

--- a/src/types/jsxElement.ts
+++ b/src/types/jsxElement.ts
@@ -1,0 +1,1 @@
+export type JSXElement = JSX.Element | null;


### PR DESCRIPTION
Closes #27 

## Changes

- Implements CFPB DS global eyebrow
- Adapts their .less styles (couldn't access .less variables or use functions such as unit())
- Adds stories, tests

## How to test this PR

1. git checkout banner && yarn 
2. yarn test
3. yarn start -> click around

## Screenshots
<img width="1557" alt="Screen Shot 2023-04-27 at 2 32 51 PM" src="https://user-images.githubusercontent.com/2592907/234984378-06853412-2ec4-4bd0-af35-be5fae0608fd.png">
 <img width="1561" alt="Screen Shot 2023-04-27 at 2 33 00 PM" src="https://user-images.githubusercontent.com/2592907/234984412-a53e8a4b-1c85-46ea-b9e8-850f0a1c2dc9.png">


