### PR TITLE
Multiselect Dropdown - Tab to navigate instead of select

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@cfpb/cfpb-design-system": "^0.21.13",
+    "@cfpb/cfpb-forms": "^0.24.0",
     "@tanstack/react-query": "4.13.5",
     "@tanstack/react-table": "^8.8.0",
     "classnames": "^2.3.2",

--- a/src/components/Dropdown.stories.tsx
+++ b/src/components/Dropdown.stories.tsx
@@ -54,17 +54,36 @@ export const Disabled: Story = {
 }};
 
 export const MultiSelect: Story = {
-  args:{
-  ...DefaultDropdown.args,
-  options: [
-    ...options,
-    {
-      value: 'long',
-      label:
-        'Multiselect options can also contain long words that will be wrapped like supercalifragilisticexpialidocious'
-    }
-  ],
-  id: 'multi',
-  isMulti: true,
-  label: 'Multi-select'
-}};
+  args: {
+    ...DefaultDropdown.args,
+    options: [
+      ...options,
+      {
+        value: 'long',
+        label:
+          'Multiselect options can also contain long words that will be wrapped like supercalifragilisticexpialidocious'
+      }
+    ],
+    id: 'multi',
+    isMulti: true,
+    label: 'Multi-select'
+  }
+};
+
+export const MultiSelectWithDefaultValue: Story = {
+  args: {
+    ...DefaultDropdown.args,
+    options: [
+      ...options,
+      {
+        value: 'long',
+        label:
+          'Multiselect options can also contain long words that will be wrapped like supercalifragilisticexpialidocious'
+      }
+    ],
+    defaultValue: [options[0]],
+    id: 'multi',
+    isMulti: true,
+    label: 'Multi-select'
+  }
+};

--- a/src/components/Dropdown.stories.tsx
+++ b/src/components/Dropdown.stories.tsx
@@ -22,12 +22,11 @@ type Story = StoryObj<typeof meta>;
 
 const LAST_ELEMENT = -1;
 
-const options = [
+export const options = [
   { value: 'value1', label: 'Option A' },
   { value: 'value2', label: 'Option B' },
   { value: 'value3', label: 'Option C' }
 ];
-
 
 export const DefaultDropdown: Story = {
   args: {

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -50,15 +50,13 @@ const filterOptions = (
   selected: PropsValue<SelectOption>,
   isMulti: boolean
 ): OptionsOrGroups<SelectOption, GroupBase<SelectOption>> => {
-  if (!selected || !options)
+  if (!selected || !isMulti)
     return options as OptionsOrGroups<SelectOption, GroupBase<SelectOption>>;
 
-  if (isMulti)
-    return (options as SelectOption[]).filter(
-      o => !(selected as SelectOption[]).map(s => s.value).includes(o.value)
-    );
+  return (options as SelectOption[]).filter(
+    o => !(selected as SelectOption[]).map(s => s.value).includes(o.value)
+  );
 
-  return options as OptionsOrGroups<SelectOption, GroupBase<SelectOption>>;
 };
 
 interface DropdownProperties {

--- a/src/components/DropdownPills.tsx
+++ b/src/components/DropdownPills.tsx
@@ -1,0 +1,89 @@
+import type { ReactEventHandler } from 'react';
+import type { PropsValue } from 'react-select';
+import type { SelectOption } from './Dropdown';
+import { Icon } from './Icon';
+import { Label } from './Label';
+
+/**
+ * Event Handlers
+ */
+
+function onCloser(
+  index: number,
+  onChange: (result: PropsValue<SelectOption>) => void,
+  selected?: PropsValue<SelectOption>
+): ReactEventHandler<HTMLButtonElement> {
+  return () => {
+    if (!selected || !Array.isArray(selected)) return;
+    const result = selected.filter((_, index_) => index_ !== index);
+    onChange(result);
+  };
+}
+
+function onKeyCloser(
+  event: React.KeyboardEvent<HTMLButtonElement>,
+  functionClose: ReactEventHandler<HTMLButtonElement>
+): void {
+  const validKeys = ['Enter', 'Delete', 'Backspace'];
+  if (validKeys.includes(event.key)) functionClose(event);
+}
+
+/**
+ * Components
+ */
+
+interface DropdownPillProperties {
+  value: string;
+  onClose: ReactEventHandler<HTMLButtonElement>;
+}
+export const DropdownPill = ({
+  value,
+  onClose
+}: DropdownPillProperties): JSX.Element => (
+  <li className='pill'>
+    <button
+      type='button'
+      onClick={onClose}
+      onKeyDown={(event): void => onKeyCloser(event, onClose)}
+    >
+      <Label htmlFor={value} inline>
+        {value}
+        <div>
+          <Icon name='error' />
+        </div>
+      </Label>
+    </button>
+  </li>
+);
+
+interface DropdownPillsProperties {
+  selected: PropsValue<SelectOption>;
+  isMulti: boolean;
+  onChange: (event: PropsValue<SelectOption>) => void;
+}
+
+export const DropdownPills = ({
+  selected,
+  isMulti,
+  onChange
+}: DropdownPillsProperties): JSX.Element | null => {
+  if (
+    !isMulti ||
+    !selected ||
+    !Array.isArray(selected) ||
+    selected.length === 0
+  )
+    return null;
+
+  return (
+    <ul className='o-multiselect_choices pills'>
+      {selected.map(({ value, label }: SelectOption, index: number) => (
+        <DropdownPill
+          key={value}
+          value={label}
+          onClose={onCloser(index, onChange, selected)}
+        />
+      ))}
+    </ul>
+  );
+};

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -14,17 +14,13 @@ export const Label = ({
   inline = false,
   htmlFor,
   className,
-  ...LabelProperties
+  ...other
 }: JSX.IntrinsicElements['label'] & LabelProperties): React.ReactElement => {
   const styles = [...baseStyles, inline ? '' : 'a-label__heading'];
   const classes = [className, ...styles];
 
   return (
-    <label
-      {...LabelProperties}
-      className={classnames(classes)}
-      htmlFor={htmlFor}
-    >
+    <label {...other} className={classnames(classes)} htmlFor={htmlFor}>
       {children}
     </label>
   );

--- a/src/types/untyped.d.ts
+++ b/src/types/untyped.d.ts
@@ -1,2 +1,3 @@
 // Plain JS libs
 declare module '@cfpb/cfpb-expandables/src/Expandable';
+declare module '@cfpb/cfpb-forms';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1066,10 +1066,25 @@
     "@cfpb/cfpb-core" "^0.21.0"
     "@cfpb/cfpb-icons" "^0.21.11"
 
+"@cfpb/cfpb-buttons@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-buttons/-/cfpb-buttons-0.24.0.tgz#17cabd966f04e4911bfd7da39f261b33c182041b"
+  integrity sha512-L0qPAcbZ69n7jvIQ3Zb2c78i2hgK9OSsXlE9qNCQOFjeUsabjqB20w9I/3lwfho1erN/F2rdmfRncQg9TD4tzQ==
+  dependencies:
+    "@cfpb/cfpb-core" "^0.24.0"
+    "@cfpb/cfpb-icons" "^0.24.0"
+
 "@cfpb/cfpb-core@^0.21.0":
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/@cfpb/cfpb-core/-/cfpb-core-0.21.0.tgz#5e29652c1d57cc7762f01a0bdc8bb75844f6fc0c"
   integrity sha512-k1W6dUQ+gkTaB6mF8CvZclR9JG7F6LlRR/yrO6xMwCC8PekZn9c9ZEpimnTHZh7DH5+kg3tPErOTJ84Kv83mCQ==
+  dependencies:
+    normalize-css "^2.0.0"
+
+"@cfpb/cfpb-core@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-core/-/cfpb-core-0.24.0.tgz#06b3c59286f4f31fa1061cdf4b9b36433fcd3e2c"
+  integrity sha512-emTntgqOseCmfcPRXtVSxoDW68pZ2wjRsAF+wAH95QIAtd172DxuXm+KywCDuyyiOrgxV6BlcGhAoIVEitX8lg==
   dependencies:
     normalize-css "^2.0.0"
 
@@ -1110,6 +1125,16 @@
     "@cfpb/cfpb-grid" "^0.21.0"
     "@cfpb/cfpb-icons" "^0.21.11"
 
+"@cfpb/cfpb-forms@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-forms/-/cfpb-forms-0.24.0.tgz#a4281aa677edf1cf1613c4e3f34a706ee42e8d47"
+  integrity sha512-CXUVm6VeJfjJd5SLudPKc23gJjfdSEr+JOFoO/5H2pPZYqCRyCk1nHc0RvIxKF5TwuB8sGC/ybN5vyYo0NYfrw==
+  dependencies:
+    "@cfpb/cfpb-buttons" "^0.24.0"
+    "@cfpb/cfpb-core" "^0.24.0"
+    "@cfpb/cfpb-grid" "^0.24.0"
+    "@cfpb/cfpb-icons" "^0.24.0"
+
 "@cfpb/cfpb-grid@^0.21.0":
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/@cfpb/cfpb-grid/-/cfpb-grid-0.21.0.tgz#8ce5ede5936e6d8790139a20dcdf635a699d8954"
@@ -1117,10 +1142,22 @@
   dependencies:
     normalize-css "^2.0.0"
 
+"@cfpb/cfpb-grid@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-grid/-/cfpb-grid-0.24.0.tgz#acf89a3544adcab6c171d695f350b93dac5c418b"
+  integrity sha512-Qj74AVQyiJl9GEADZIpdk1MBUyPxhO8tIUkCQj+iujyr1YVpHI0zlxDR5wcwOB/+AAJd4Kw7h4987zDZOtv8bQ==
+  dependencies:
+    normalize-css "^2.0.0"
+
 "@cfpb/cfpb-icons@^0.21.11":
   version "0.21.11"
   resolved "https://registry.yarnpkg.com/@cfpb/cfpb-icons/-/cfpb-icons-0.21.11.tgz#8d293d4281ede28ba5b4bd828174ded4265e7b42"
   integrity sha512-MGGhuEIqUsL8KLXZZR5UYn54LCoEvAT169gF2iEINE0emXd20T1QMbWXWn4XFJz1VxguLOdIpSjPseJVfjHhkA==
+
+"@cfpb/cfpb-icons@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-icons/-/cfpb-icons-0.24.0.tgz#74467eb627f304e2a93f4a4159958e8da2ab6946"
+  integrity sha512-HxdpjbT+4Sk50NAdm5b4Deig2FjiKJjJzR/FcVeDd7Q2ylqdd6dLL3zODVruZolxi820j2WbLgEnU1wCQHyUUw==
 
 "@cfpb/cfpb-layout@^0.21.12":
   version "0.21.12"


### PR DESCRIPTION
Closes #28 

Improves keyboard accessibility by making `Tab` act as one might expect.

## Changes

- Tab / Shift + Tab will navigate the dropdown instead of selecting the highlighted option
- Moves DropdownPills into new file to clean up Dropdown.tsx
- Adds a story for Multiselect w/ Default Value
- Cleans up some variable naming in Label.tsx

## How to test this PR

1. yarn && yarn start
2. Open http://localhost:6006/?path=/story/components-dropdown--multi-select
3. Click to open menu
4. Hit `Tab` / `Shift + Tab` to move down/up option list
5. Hit `Escape` > `Tab` to navigate away from Dropdown


