### PR TITLE
[Tests] Dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "preview": "vite preview",
     "preview:test": "start-server-and-test preview http://localhost:4173",
     "test": "vitest",
+    "test-report": "open coverage/lcov-report/index.html",
     "test:ci": "vitest run",
     "test:e2e": "yarn preview:test 'cypress open'",
     "test:e2e:headless": "yarn preview:test 'cypress run'",

--- a/src/components/Dropdown.test.tsx
+++ b/src/components/Dropdown.test.tsx
@@ -1,0 +1,218 @@
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Dropdown } from './Dropdown';
+import { options } from './Dropdown.stories';
+
+/**
+ * TODO
+ *
+ * We get lots of warnings about needing to wrap in act(...) because actions
+ * update React state but, when wrapped, some of the actions don't update
+ * the rendered element. I've wrapped what I could to eliminate as many
+ * warnings as I could.
+ *
+ * I have tried some of the workarounds outlined in the article below
+ * but have not had any success eliminating the warnings.
+ *
+ * https://kentcdodds.com/blog/fix-the-not-wrapped-in-act-warning
+ */
+
+const onSelect = (): null => null;
+
+const label = '-default dropdown-';
+const id = 'anID';
+const placeholder = 'HOLD MY PLACE';
+
+/**
+ * Single select
+ */
+describe('Default Dropdown', () => {
+  const defaultProps = { id, label, options, onSelect, placeholder };
+
+  it('Renders default labels correctly', () => {
+    render(<Dropdown {...{ id, options, onSelect }} />);
+    expect(screen.queryByText(label)).not.toBeInTheDocument();
+    expect(screen.getByText('Dropdown w/ Multi-select')).toBeInTheDocument();
+    expect(screen.getByText('Select...')).toBeInTheDocument();
+  });
+
+  it('Renders provided labels correctly', () => {
+    render(<Dropdown {...defaultProps} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(screen.getByText(placeholder)).toBeInTheDocument();
+  });
+
+  it('(Mouse) Selects an option', async () => {
+    const optionLabel = 'Option A';
+    const user = userEvent.setup();
+
+    render(<Dropdown {...defaultProps} />);
+    await act(async () => {
+      await user.click(screen.getByText(label));
+    });
+
+    expect(screen.getByText(optionLabel)).toBeInTheDocument();
+    await act(async () => {
+      await user.click(screen.getByText(optionLabel));
+    });
+
+    const selectedOption = screen.getByText(optionLabel);
+    expect(selectedOption).toBeInTheDocument();
+    expect(selectedOption.getAttribute('class')).toMatch(/singlevalue/gi);
+  });
+
+  it('(Keyboard) Selects an option', async () => {
+    const optionLabel = 'Option C';
+    const user = userEvent.setup();
+
+    render(<Dropdown {...defaultProps} />);
+
+    expect(screen.queryByText(optionLabel)).not.toBeInTheDocument();
+    await user.click(screen.getByText(label));
+    await user.keyboard('{Tab}{Tab}{Enter}');
+
+    const selectedOption = screen.getByText(optionLabel);
+    expect(selectedOption).toBeInTheDocument();
+    expect(selectedOption.getAttribute('class')).toMatch(/singlevalue/gi);
+  });
+
+  it('Correctly displays a defaultValue', async () => {
+    render(
+      <Dropdown
+        {...{
+          id,
+          label,
+          options,
+          onSelect,
+          placeholder,
+          defaultValue: options.at(-1)
+        }}
+      />
+    );
+
+    const selectedOption = screen.getByText('Option C');
+    expect(selectedOption).toBeInTheDocument();
+    expect(selectedOption.getAttribute('class')).toMatch(/singlevalue/gi);
+
+    expect(screen.queryByText('Option A')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Multi-select
+ */
+describe('Multi-select Dropdown', () => {
+  const multiProperties = {
+    id,
+    label,
+    options,
+    onSelect,
+    placeholder,
+    isMulti: true
+  };
+
+  it('(Mouse) Selects an option and displays pill', async () => {
+    const optionLabel = 'Option A';
+    const user = userEvent.setup();
+
+    render(<Dropdown {...multiProperties} />);
+    await act(async () => {
+      await user.click(screen.getByText(label));
+    });
+
+    expect(screen.getByText(optionLabel)).toBeInTheDocument();
+    expect(screen.getByText(optionLabel).getAttribute('class')).toMatch(
+      /option/gi
+    );
+    await act(async () => {
+      await user.click(screen.getByText(optionLabel));
+    });
+
+    const pills = screen.queryAllByRole('listitem');
+    expect(pills.length).toBe(1);
+
+    const selectedOption = pills[0];
+    expect(selectedOption).toHaveClass('pill');
+    expect(selectedOption).toHaveTextContent(optionLabel);
+  });
+
+  it('(Keyboard) Navigation, selection, de-selection', async () => {
+    const optionLabel = 'Option C';
+    const user = userEvent.setup();
+
+    render(<Dropdown {...multiProperties} />);
+
+    const beforeSelection = screen.queryAllByRole('listitem');
+
+    expect(beforeSelection.length).toBe(0);
+    expect(screen.queryByText(optionLabel)).not.toBeInTheDocument();
+
+    // Choose 'Option C' and close menu
+    await user.click(screen.getByText(label));
+    await user.keyboard(
+      '{Tab}{Tab}{Shift>}{Tab}{/Shift}{Tab}{Enter}{Escape}{Tab}'
+    );
+
+    // Verify other options are hidden
+    expect(screen.queryByText('Option A')).not.toBeInTheDocument();
+    expect(screen.queryByText('Option B')).not.toBeInTheDocument();
+
+    // Verify pill displayed
+    expect(screen.getByText(optionLabel)).toBeInTheDocument();
+    const afterSelection = screen.queryAllByRole('listitem');
+    expect(afterSelection.length).toBe(1);
+    expect(afterSelection[0]).toHaveClass('pill');
+    expect(afterSelection[0]).toHaveTextContent(optionLabel);
+
+    // Delete selection
+    await act(async () => {
+      await user.click(screen.getByText(label));
+      await user.keyboard('{Delete}');
+    });
+
+    // No pills
+    expect(screen.queryAllByRole('listitem').length).toBe(0);
+  });
+
+  it('(Keyboard) Pills interaction', async () => {
+    const optionLabel = 'Option C';
+    const user = userEvent.setup();
+
+    // All options selected by default
+    render(<Dropdown {...multiProperties} defaultValue={options} />);
+
+    // Verify pills displayed
+    const afterSelection = screen.queryAllByRole('listitem');
+    expect(afterSelection.length).toBe(3);
+    expect(afterSelection[2]).toHaveClass('pill');
+    expect(afterSelection[2]).toHaveTextContent(optionLabel);
+
+    // Focus on pill and delete selection
+    await act(async () => {
+      await user.click(screen.getByText(label));
+      await user.keyboard('{Shift}{Tab}{Tab}{/Shift}{Enter}');
+    });
+
+    // Verify correct option's pill was removed, while others remain
+    const afterDelete = screen.queryAllByRole('listitem');
+    expect(afterDelete.length).toBe(2);
+    expect(afterDelete[0]).toHaveTextContent('Option B');
+    expect(afterDelete[1]).toHaveTextContent('Option C');
+  });
+
+  it('Correctly displays a default option', async () => {
+    render(
+      <Dropdown
+        {...{
+          ...multiProperties,
+          defaultValue: [options[1], options[2]]
+        }}
+      />
+    );
+
+    expect(screen.queryByText('Option A')).not.toBeInTheDocument();
+    expect(screen.getByText('Option B')).toBeInTheDocument();
+    expect(screen.getByText('Option C')).toBeInTheDocument();
+  });
+});

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -62,10 +62,10 @@ const filterOptions = (
 interface DropdownProperties {
   id: string;
   options: SelectOption[];
+  onSelect: (event: OnChangeValue<SelectOption, boolean>) => void;
   isMulti?: boolean;
   defaultValue?: PropsValue<SelectOption>;
   label?: string;
-  onSelect: (event: OnChangeValue<SelectOption, boolean>) => void;
   isDisabled?: boolean;
 }
 
@@ -77,7 +77,7 @@ export function Dropdown({
   isMulti = false,
   options,
   defaultValue,
-  id = 'dropdown',
+  id,
   label = 'Dropdown w/ Multi-select',
   onSelect,
   ...rest

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -53,10 +53,12 @@ const filterOptions = (
   if (!selected || !isMulti)
     return options as OptionsOrGroups<SelectOption, GroupBase<SelectOption>>;
 
-  return (options as SelectOption[]).filter(
-    o => !(selected as SelectOption[]).map(s => s.value).includes(o.value)
-  );
+  if (isMulti)
+    return (options as SelectOption[]).filter(
+      o => !(selected as SelectOption[]).map(s => s.value).includes(o.value)
+    );
 
+  return options as OptionsOrGroups<SelectOption, GroupBase<SelectOption>>;
 };
 
 interface DropdownProperties {

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -109,10 +109,12 @@ export function Dropdown({
     selectReference.current?.focus();
   }, []);
 
+  const labelID = `${id}-label`;
+
   return (
     <div className='m-form-field m-form-field__select'>
       {!!label && (
-        <Label htmlFor={id} onClick={onLabelClick}>
+        <Label id={labelID} htmlFor={id} onClick={onLabelClick}>
           {label}
         </Label>
       )}
@@ -122,6 +124,8 @@ export function Dropdown({
         onChange={onChange}
       />
       <Select
+        inputId={id}
+        aria-labelledby={labelID}
         openMenuOnFocus
         ref={selectReference as Ref<any>}
         tabSelectsValue={false}

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,12 +1,13 @@
-import type { KeyboardEvent } from 'react';
-import { useRef, useState } from 'react';
+import type { KeyboardEvent, Ref } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type {
   CSSObjectWithLabel,
   ControlProps,
   GroupBase,
   OnChangeValue,
   OptionsOrGroups,
-  PropsValue
+  PropsValue,
+  SelectInstance
 } from 'react-select';
 import Select, { createFilter } from 'react-select';
 import { DropdownPills } from './DropdownPills';
@@ -56,7 +57,6 @@ const filterOptions = (
   return (options as SelectOption[]).filter(
     o => !(selected as SelectOption[]).map(s => s.value).includes(o.value)
   );
-
 };
 
 interface DropdownProperties {
@@ -86,15 +86,15 @@ export function Dropdown({
     defaultValue ?? []
   );
 
-  const selectReference = useRef(null);
+  const selectReference = useRef<SelectInstance>(null);
 
   // Store updated list of selected items
-  function onChange(option: PropsValue<SelectOption>): void {
+  const onChange = useCallback((option: PropsValue<SelectOption>) => {
     onSelect(option);
     setSelected(option);
-  }
+  }, []);
 
-  function onKeyDown(event: KeyboardEvent<HTMLDivElement>): void {
+  const onKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (event.key === 'Tab' && selectReference.current?.state?.focusedOption) {
       event.preventDefault();
@@ -102,12 +102,12 @@ export function Dropdown({
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       selectReference.current.focusOption(direction);
     }
-  }
+  }, []);
 
-  function onLabelClick(): void {
+  const onLabelClick = useCallback(() => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     selectReference.current?.focus();
-  }
+  }, []);
 
   return (
     <div className='m-form-field m-form-field__select'>
@@ -123,7 +123,7 @@ export function Dropdown({
       />
       <Select
         openMenuOnFocus
-        ref={selectReference}
+        ref={selectReference as Ref<any>}
         tabSelectsValue={false}
         onKeyDown={onKeyDown}
         isMulti={isMulti}

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -53,12 +53,10 @@ const filterOptions = (
   if (!selected || !isMulti)
     return options as OptionsOrGroups<SelectOption, GroupBase<SelectOption>>;
 
-  if (isMulti)
-    return (options as SelectOption[]).filter(
-      o => !(selected as SelectOption[]).map(s => s.value).includes(o.value)
-    );
+  return (options as SelectOption[]).filter(
+    o => !(selected as SelectOption[]).map(s => s.value).includes(o.value)
+  );
 
-  return options as OptionsOrGroups<SelectOption, GroupBase<SelectOption>>;
 };
 
 interface DropdownProperties {

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -89,23 +89,23 @@ export function Dropdown({
   const selectReference = useRef<SelectInstance>(null);
 
   // Store updated list of selected items
-  const onChange = useCallback((option: PropsValue<SelectOption>) => {
-    onSelect(option);
-    setSelected(option);
-  }, []);
+  const onChange = useCallback(
+    (option: PropsValue<SelectOption>) => {
+      onSelect(option);
+      setSelected(option);
+    },
+    [onSelect]
+  );
 
   const onKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (event.key === 'Tab' && selectReference.current?.state?.focusedOption) {
+    if (event.key === 'Tab' && selectReference.current?.state.focusedOption) {
       event.preventDefault();
       const direction = event.shiftKey ? 'up' : 'down';
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       selectReference.current.focusOption(direction);
     }
   }, []);
 
   const onLabelClick = useCallback(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     selectReference.current?.focus();
   }, []);
 

--- a/src/components/DropdownPills.test.tsx
+++ b/src/components/DropdownPills.test.tsx
@@ -1,0 +1,73 @@
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { options } from './Dropdown.stories';
+import { DropdownPill, DropdownPills, onCloser } from './DropdownPills';
+
+describe('DropdownPill', () => {
+  // Never happens due to checks in DropdownPills but this is for full test coverage
+  it('onCloser called with nothing selected does not call onChange', async () => {
+    const user = userEvent.setup();
+    const testLabel = 'Test Value';
+
+    const selected = null;
+    const onChange = vi.fn();
+    const onCloseListener = onCloser(0, onChange, selected);
+
+    render(<DropdownPill value={testLabel} onClose={onCloseListener} />);
+    await act(async () => {
+      await user.click(screen.getByText(testLabel));
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('DropdownPills', () => {
+  it('Calls onChange when pill is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const selected = options[0];
+
+    render(<DropdownPills selected={[selected]} onChange={onChange} isMulti />);
+
+    const pills = screen.queryAllByRole('button');
+    expect(pills.length).toBe(1);
+
+    const selectedOption = pills[0];
+    expect(selectedOption).not.toHaveClass('pill');
+    expect(selectedOption).toHaveTextContent(selected.label);
+    expect(onChange).not.toBeCalled();
+    await act(async () => {
+      await user.click(selectedOption);
+    });
+
+    expect(onChange).toBeCalled();
+    expect(onChange).toBeCalledWith([]);
+  });
+
+  it('(Keyboard) Calls onChange when pill is activated', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const selected = options[0];
+
+    render(<DropdownPills selected={[selected]} onChange={onChange} isMulti />);
+
+    const pills = screen.queryAllByRole('button');
+    expect(pills.length).toBe(1);
+
+    const selectedOption = pills[0];
+    expect(selectedOption).not.toHaveClass('pill');
+    expect(selectedOption).toHaveTextContent(selected.label);
+    expect(onChange).not.toBeCalled();
+    selectedOption.focus();
+    await act(async () => {
+      await user.keyboard('p');
+    });
+
+    expect(onChange).not.toBeCalled();
+
+    await user.keyboard('{Enter}');
+    expect(onChange).toBeCalled();
+    expect(onChange).toBeCalledWith([]);
+  });
+});

--- a/src/components/DropdownPills.tsx
+++ b/src/components/DropdownPills.tsx
@@ -8,7 +8,7 @@ import { Label } from './Label';
  * Event Handlers
  */
 
-function onCloser(
+export function onCloser(
   index: number,
   onChange: (result: PropsValue<SelectOption>) => void,
   selected?: PropsValue<SelectOption>
@@ -57,9 +57,9 @@ export const DropdownPill = ({
 );
 
 interface DropdownPillsProperties {
-  selected: PropsValue<SelectOption>;
-  isMulti: boolean;
   onChange: (event: PropsValue<SelectOption>) => void;
+  selected: PropsValue<SelectOption>;
+  isMulti?: boolean;
 }
 
 export const DropdownPills = ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,6 +1061,7 @@
   resolved "https://registry.yarnpkg.com/@cfpb/cfpb-atomic-component/-/cfpb-atomic-component-0.26.0.tgz#14a038c7c10122183cde07c19d79afaac0c8e0ad"
   integrity sha512-l0P/BWXJFcHuZRPLKLSMM40BPIMi/b7BfkPT5ZXcStK1/BzZJW6qF19963DMTO0a7DwjMU2cThXhNwo57JWadg==
 
+<<<<<<< HEAD
 "@cfpb/cfpb-buttons@^0.25.0":
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/@cfpb/cfpb-buttons/-/cfpb-buttons-0.25.0.tgz#5c67094ce26a26ed6fb2dfc400f51924c1b8c98c"
@@ -1087,6 +1088,105 @@
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/@cfpb/cfpb-design-system/-/cfpb-design-system-0.25.0.tgz#ad54bdbda34138900647d25bcf38e3b99b1e7ac8"
   integrity sha512-c7Uy0dU006EVAh0mTnhUZUga+EDyfY1/sJI2DeAc/AOHQb/D/IshrlM/WF7yFi/NLsL28Wyh4By93MfqITGnkw==
+=======
+"@cfpb/cfpb-buttons@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-buttons/-/cfpb-buttons-0.24.0.tgz#17cabd966f04e4911bfd7da39f261b33c182041b"
+  integrity sha512-L0qPAcbZ69n7jvIQ3Zb2c78i2hgK9OSsXlE9qNCQOFjeUsabjqB20w9I/3lwfho1erN/F2rdmfRncQg9TD4tzQ==
+  dependencies:
+    "@cfpb/cfpb-core" "^0.24.0"
+    "@cfpb/cfpb-icons" "^0.24.0"
+
+"@cfpb/cfpb-core@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-core/-/cfpb-core-0.21.0.tgz#5e29652c1d57cc7762f01a0bdc8bb75844f6fc0c"
+  integrity sha512-k1W6dUQ+gkTaB6mF8CvZclR9JG7F6LlRR/yrO6xMwCC8PekZn9c9ZEpimnTHZh7DH5+kg3tPErOTJ84Kv83mCQ==
+  dependencies:
+    normalize-css "^2.0.0"
+
+"@cfpb/cfpb-core@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-core/-/cfpb-core-0.24.0.tgz#06b3c59286f4f31fa1061cdf4b9b36433fcd3e2c"
+  integrity sha512-emTntgqOseCmfcPRXtVSxoDW68pZ2wjRsAF+wAH95QIAtd172DxuXm+KywCDuyyiOrgxV6BlcGhAoIVEitX8lg==
+  dependencies:
+    normalize-css "^2.0.0"
+
+"@cfpb/cfpb-design-system@^0.21.13":
+  version "0.21.13"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-design-system/-/cfpb-design-system-0.21.13.tgz#a15496355d550b4db0090da354d12624b4b03aa5"
+  integrity sha512-s74cv81+4DkWizfuuk6+FvqeeVxHB2GSYSzd7eAYZ95Bc7jRQhc2l8AwzZ+408mvK4Fkh5V6x0++iQVeVfY2hw==
+  dependencies:
+    "@cfpb/cfpb-atomic-component" "^0.21.9"
+    "@cfpb/cfpb-buttons" "^0.21.11"
+    "@cfpb/cfpb-core" "^0.21.0"
+    "@cfpb/cfpb-expandables" "^0.21.11"
+    "@cfpb/cfpb-forms" "^0.21.11"
+    "@cfpb/cfpb-grid" "^0.21.0"
+    "@cfpb/cfpb-icons" "^0.21.11"
+    "@cfpb/cfpb-layout" "^0.21.12"
+    "@cfpb/cfpb-notifications" "^0.21.11"
+    "@cfpb/cfpb-pagination" "^0.21.11"
+    "@cfpb/cfpb-tables" "^0.21.9"
+    "@cfpb/cfpb-typography" "^0.21.13"
+
+"@cfpb/cfpb-expandables@^0.21.11":
+  version "0.21.11"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-expandables/-/cfpb-expandables-0.21.11.tgz#41795ff990f9e404c9a0055bd0f5b339fa7e2b17"
+  integrity sha512-NNAcmIHNW39yNwt74N0L5DbOdJRPUby6FO0LJNU3JQbRE4o9QxQTPnK6BInfw8Rrzo/dmBPRjvl7zuHTGZH0hg==
+  dependencies:
+    "@cfpb/cfpb-atomic-component" "^0.21.9"
+    "@cfpb/cfpb-core" "^0.21.0"
+    "@cfpb/cfpb-icons" "^0.21.11"
+
+"@cfpb/cfpb-forms@^0.21.11":
+  version "0.21.11"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-forms/-/cfpb-forms-0.21.11.tgz#fe36c0e6baa35127411fedac82b69950a60f7138"
+  integrity sha512-QvjVjEcuXnUF0crQ60ijz35BWsyyn7W4QCrpKMdHuJ6RtQWOdM7AinLRg/gQPw8G5yuya++1LcI6rXh4hRQMQQ==
+  dependencies:
+    "@cfpb/cfpb-buttons" "^0.21.11"
+    "@cfpb/cfpb-core" "^0.21.0"
+    "@cfpb/cfpb-grid" "^0.21.0"
+    "@cfpb/cfpb-icons" "^0.21.11"
+
+"@cfpb/cfpb-forms@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-forms/-/cfpb-forms-0.24.0.tgz#a4281aa677edf1cf1613c4e3f34a706ee42e8d47"
+  integrity sha512-CXUVm6VeJfjJd5SLudPKc23gJjfdSEr+JOFoO/5H2pPZYqCRyCk1nHc0RvIxKF5TwuB8sGC/ybN5vyYo0NYfrw==
+  dependencies:
+    "@cfpb/cfpb-buttons" "^0.24.0"
+    "@cfpb/cfpb-core" "^0.24.0"
+    "@cfpb/cfpb-grid" "^0.24.0"
+    "@cfpb/cfpb-icons" "^0.24.0"
+
+"@cfpb/cfpb-grid@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-grid/-/cfpb-grid-0.21.0.tgz#8ce5ede5936e6d8790139a20dcdf635a699d8954"
+  integrity sha512-uXigNd7GZ3jLUq53RcboVC583B1N7gXmdsCtAB5E06wyauGZI0SGZm474LPDPZcR3mDcoqCLZkE3X47oYmm7lQ==
+  dependencies:
+    normalize-css "^2.0.0"
+
+"@cfpb/cfpb-grid@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-grid/-/cfpb-grid-0.24.0.tgz#acf89a3544adcab6c171d695f350b93dac5c418b"
+  integrity sha512-Qj74AVQyiJl9GEADZIpdk1MBUyPxhO8tIUkCQj+iujyr1YVpHI0zlxDR5wcwOB/+AAJd4Kw7h4987zDZOtv8bQ==
+  dependencies:
+    normalize-css "^2.0.0"
+
+"@cfpb/cfpb-icons@^0.21.11":
+  version "0.21.11"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-icons/-/cfpb-icons-0.21.11.tgz#8d293d4281ede28ba5b4bd828174ded4265e7b42"
+  integrity sha512-MGGhuEIqUsL8KLXZZR5UYn54LCoEvAT169gF2iEINE0emXd20T1QMbWXWn4XFJz1VxguLOdIpSjPseJVfjHhkA==
+
+"@cfpb/cfpb-icons@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-icons/-/cfpb-icons-0.24.0.tgz#74467eb627f304e2a93f4a4159958e8da2ab6946"
+  integrity sha512-HxdpjbT+4Sk50NAdm5b4Deig2FjiKJjJzR/FcVeDd7Q2ylqdd6dLL3zODVruZolxi820j2WbLgEnU1wCQHyUUw==
+
+"@cfpb/cfpb-layout@^0.21.12":
+  version "0.21.12"
+  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-layout/-/cfpb-layout-0.21.12.tgz#673bc24c910914ad4ad246b20588f2eaa5bb58d1"
+  integrity sha512-dFMur+VwziNA3XIG8FqRZNwQr/8SP01mbxOt+C1sarxjd/u2qPr+fwCrwSXqb234uyhigXo1dxC6N43JnZ3uAw==
+>>>>>>> e6bad00 (Add @cfpb-forms lib)
   dependencies:
     "@cfpb/cfpb-atomic-component" "^0.25.0"
     "@cfpb/cfpb-buttons" "^0.25.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,7 +1061,6 @@
   resolved "https://registry.yarnpkg.com/@cfpb/cfpb-atomic-component/-/cfpb-atomic-component-0.26.0.tgz#14a038c7c10122183cde07c19d79afaac0c8e0ad"
   integrity sha512-l0P/BWXJFcHuZRPLKLSMM40BPIMi/b7BfkPT5ZXcStK1/BzZJW6qF19963DMTO0a7DwjMU2cThXhNwo57JWadg==
 
-<<<<<<< HEAD
 "@cfpb/cfpb-buttons@^0.25.0":
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/@cfpb/cfpb-buttons/-/cfpb-buttons-0.25.0.tgz#5c67094ce26a26ed6fb2dfc400f51924c1b8c98c"
@@ -1088,105 +1087,6 @@
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/@cfpb/cfpb-design-system/-/cfpb-design-system-0.25.0.tgz#ad54bdbda34138900647d25bcf38e3b99b1e7ac8"
   integrity sha512-c7Uy0dU006EVAh0mTnhUZUga+EDyfY1/sJI2DeAc/AOHQb/D/IshrlM/WF7yFi/NLsL28Wyh4By93MfqITGnkw==
-=======
-"@cfpb/cfpb-buttons@^0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-buttons/-/cfpb-buttons-0.24.0.tgz#17cabd966f04e4911bfd7da39f261b33c182041b"
-  integrity sha512-L0qPAcbZ69n7jvIQ3Zb2c78i2hgK9OSsXlE9qNCQOFjeUsabjqB20w9I/3lwfho1erN/F2rdmfRncQg9TD4tzQ==
-  dependencies:
-    "@cfpb/cfpb-core" "^0.24.0"
-    "@cfpb/cfpb-icons" "^0.24.0"
-
-"@cfpb/cfpb-core@^0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-core/-/cfpb-core-0.21.0.tgz#5e29652c1d57cc7762f01a0bdc8bb75844f6fc0c"
-  integrity sha512-k1W6dUQ+gkTaB6mF8CvZclR9JG7F6LlRR/yrO6xMwCC8PekZn9c9ZEpimnTHZh7DH5+kg3tPErOTJ84Kv83mCQ==
-  dependencies:
-    normalize-css "^2.0.0"
-
-"@cfpb/cfpb-core@^0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-core/-/cfpb-core-0.24.0.tgz#06b3c59286f4f31fa1061cdf4b9b36433fcd3e2c"
-  integrity sha512-emTntgqOseCmfcPRXtVSxoDW68pZ2wjRsAF+wAH95QIAtd172DxuXm+KywCDuyyiOrgxV6BlcGhAoIVEitX8lg==
-  dependencies:
-    normalize-css "^2.0.0"
-
-"@cfpb/cfpb-design-system@^0.21.13":
-  version "0.21.13"
-  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-design-system/-/cfpb-design-system-0.21.13.tgz#a15496355d550b4db0090da354d12624b4b03aa5"
-  integrity sha512-s74cv81+4DkWizfuuk6+FvqeeVxHB2GSYSzd7eAYZ95Bc7jRQhc2l8AwzZ+408mvK4Fkh5V6x0++iQVeVfY2hw==
-  dependencies:
-    "@cfpb/cfpb-atomic-component" "^0.21.9"
-    "@cfpb/cfpb-buttons" "^0.21.11"
-    "@cfpb/cfpb-core" "^0.21.0"
-    "@cfpb/cfpb-expandables" "^0.21.11"
-    "@cfpb/cfpb-forms" "^0.21.11"
-    "@cfpb/cfpb-grid" "^0.21.0"
-    "@cfpb/cfpb-icons" "^0.21.11"
-    "@cfpb/cfpb-layout" "^0.21.12"
-    "@cfpb/cfpb-notifications" "^0.21.11"
-    "@cfpb/cfpb-pagination" "^0.21.11"
-    "@cfpb/cfpb-tables" "^0.21.9"
-    "@cfpb/cfpb-typography" "^0.21.13"
-
-"@cfpb/cfpb-expandables@^0.21.11":
-  version "0.21.11"
-  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-expandables/-/cfpb-expandables-0.21.11.tgz#41795ff990f9e404c9a0055bd0f5b339fa7e2b17"
-  integrity sha512-NNAcmIHNW39yNwt74N0L5DbOdJRPUby6FO0LJNU3JQbRE4o9QxQTPnK6BInfw8Rrzo/dmBPRjvl7zuHTGZH0hg==
-  dependencies:
-    "@cfpb/cfpb-atomic-component" "^0.21.9"
-    "@cfpb/cfpb-core" "^0.21.0"
-    "@cfpb/cfpb-icons" "^0.21.11"
-
-"@cfpb/cfpb-forms@^0.21.11":
-  version "0.21.11"
-  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-forms/-/cfpb-forms-0.21.11.tgz#fe36c0e6baa35127411fedac82b69950a60f7138"
-  integrity sha512-QvjVjEcuXnUF0crQ60ijz35BWsyyn7W4QCrpKMdHuJ6RtQWOdM7AinLRg/gQPw8G5yuya++1LcI6rXh4hRQMQQ==
-  dependencies:
-    "@cfpb/cfpb-buttons" "^0.21.11"
-    "@cfpb/cfpb-core" "^0.21.0"
-    "@cfpb/cfpb-grid" "^0.21.0"
-    "@cfpb/cfpb-icons" "^0.21.11"
-
-"@cfpb/cfpb-forms@^0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-forms/-/cfpb-forms-0.24.0.tgz#a4281aa677edf1cf1613c4e3f34a706ee42e8d47"
-  integrity sha512-CXUVm6VeJfjJd5SLudPKc23gJjfdSEr+JOFoO/5H2pPZYqCRyCk1nHc0RvIxKF5TwuB8sGC/ybN5vyYo0NYfrw==
-  dependencies:
-    "@cfpb/cfpb-buttons" "^0.24.0"
-    "@cfpb/cfpb-core" "^0.24.0"
-    "@cfpb/cfpb-grid" "^0.24.0"
-    "@cfpb/cfpb-icons" "^0.24.0"
-
-"@cfpb/cfpb-grid@^0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-grid/-/cfpb-grid-0.21.0.tgz#8ce5ede5936e6d8790139a20dcdf635a699d8954"
-  integrity sha512-uXigNd7GZ3jLUq53RcboVC583B1N7gXmdsCtAB5E06wyauGZI0SGZm474LPDPZcR3mDcoqCLZkE3X47oYmm7lQ==
-  dependencies:
-    normalize-css "^2.0.0"
-
-"@cfpb/cfpb-grid@^0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-grid/-/cfpb-grid-0.24.0.tgz#acf89a3544adcab6c171d695f350b93dac5c418b"
-  integrity sha512-Qj74AVQyiJl9GEADZIpdk1MBUyPxhO8tIUkCQj+iujyr1YVpHI0zlxDR5wcwOB/+AAJd4Kw7h4987zDZOtv8bQ==
-  dependencies:
-    normalize-css "^2.0.0"
-
-"@cfpb/cfpb-icons@^0.21.11":
-  version "0.21.11"
-  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-icons/-/cfpb-icons-0.21.11.tgz#8d293d4281ede28ba5b4bd828174ded4265e7b42"
-  integrity sha512-MGGhuEIqUsL8KLXZZR5UYn54LCoEvAT169gF2iEINE0emXd20T1QMbWXWn4XFJz1VxguLOdIpSjPseJVfjHhkA==
-
-"@cfpb/cfpb-icons@^0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-icons/-/cfpb-icons-0.24.0.tgz#74467eb627f304e2a93f4a4159958e8da2ab6946"
-  integrity sha512-HxdpjbT+4Sk50NAdm5b4Deig2FjiKJjJzR/FcVeDd7Q2ylqdd6dLL3zODVruZolxi820j2WbLgEnU1wCQHyUUw==
-
-"@cfpb/cfpb-layout@^0.21.12":
-  version "0.21.12"
-  resolved "https://registry.yarnpkg.com/@cfpb/cfpb-layout/-/cfpb-layout-0.21.12.tgz#673bc24c910914ad4ad246b20588f2eaa5bb58d1"
-  integrity sha512-dFMur+VwziNA3XIG8FqRZNwQr/8SP01mbxOt+C1sarxjd/u2qPr+fwCrwSXqb234uyhigXo1dxC6N43JnZ3uAw==
->>>>>>> e6bad00 (Add @cfpb-forms lib)
   dependencies:
     "@cfpb/cfpb-atomic-component" "^0.25.0"
     "@cfpb/cfpb-buttons" "^0.25.0"


### PR DESCRIPTION
Closes #34 

~~This builds on https://github.com/cfpb/design-stories/pull/46, so I will leave this in `Draft` until that gets merged.~~

## Changes

- React Testing Library tests for Dropdown and supporting components

## How to test this PR

1. yarn && yarn test
2. Observe all tests pass

## Notes

### How to properly type useRef? @the-raft-oar 
I have tried applying many different types to the `useRef` that gets passed to the `<Select />` in an attempt to fix the notifications such as `Property 'focusOption' does not exist on type 'never'`.  I have also tried type casting calls to `selectReference.current` but no luck on identifying at which type level these methods/properties are defined.

I've disabled the ESLint rules that I could on those lines but what remains is un-disableable. 

### Excessive warnings about wrapping state modifying actions in `act(...)`
A few instances of wrapped actions seem to fail to update the `render`ed DOM, so subsequent `expect(...)` tests fail.  React Testing Library says that their `userEvent` actions are already wrapped in `act(...)` so devs don't need to double wrap them, so why are we getting these warnings?
 
@the-raft-oar I could use a second set of eyes to see if I'm missing something here.

Source of warnings where I've skipped `act`:
  - Dropdown.test.tsx > Default Dropdown > (Keyboard) Selects an option
  - Dropdown.test.tsx > Multi-select Dropdown > (Keyboard) Navigation, selection, de-selection
