### PR TITLE
[Component] Footer

### DIFF
--- a/src/components/Footer/BackToTop.tsx
+++ b/src/components/Footer/BackToTop.tsx
@@ -1,0 +1,14 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import { Icon } from '../Icon/Icon';
+
+export const BackToTop = (): JSX.Element => (
+  <a
+    className='a-btn a-btn__secondary o-footer_top-button'
+    data-gtm_ignore='true'
+    data-js-hook='behavior_return-to-top'
+    href='#'
+  >
+    Back to top
+    <Icon name='arrow-up' />
+  </a>
+);

--- a/src/components/Footer/Footer.less
+++ b/src/components/Footer/Footer.less
@@ -1,0 +1,198 @@
+@import (reference) url('@cfpb/cfpb-design-system/src/cfpb-design-system.less');
+
+// https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/css/organisms/footer.less
+
+/* ==========================================================================
+   consumerfinance.gov
+   footer
+   ========================================================================== */
+
+/* topdoc
+  name: CF.gov site-wide footer.
+  family: cfgov-organisms
+  patterns:
+    - notes:
+        - "For the markup please see _layouts/organisms/footer.html."
+  tags:
+    - cfgov-organisms
+*/
+
+.o-footer {
+  // Adding an extra 5px to the top to account for the absolute positioned
+  // social media icons.
+  padding-top: unit((50px / @base-font-size-px), em);
+  // There is a 10px margin-bottom on the  last .o-footer_list li's, plus the
+  // 50px bottom padding = 60px of total padding at the bottom of the footer.
+  padding-bottom: unit((50px / @base-font-size-px), em);
+  border-top: 5px solid @green;
+  background: @gray-5;
+
+  &_nav-list {
+    .m-list__links();
+
+    .m-list_link {
+      font-size: unit((18px / @base-font-size-px), em);
+      .u-link__colors( @black );
+
+      .respond-to-min( @bp-sm-min, {
+        margin-right: 1em;
+
+        .u-link__hover-border();
+      } );
+
+      .respond-to-min( @bp-med-min, {
+        margin-right: unit(( @grid_gutter-width / 22px), em );
+        font-size: unit( (20px / @base-font-size-px), em );
+      } );
+    }
+
+    .m-list_link.m-list_link__disabled {
+      border-bottom: 1px dotted;
+
+      .respond-to-min( @bp-med-min, {
+        .u-link__no-border();
+      } );
+    }
+  }
+
+  &_list {
+    .m-list__links();
+
+    .m-list_link {
+      .u-link__colors( @gray-dark );
+    }
+  }
+
+  &_pre {
+    position: relative;
+    margin-bottom: unit((45px / @base-font-size-px), em);
+
+    .o-footer_top-button {
+      display: block;
+      width: 100%;
+      text-align: center;
+      // There's a standard margin between the top
+      // of the footer and the links. The button comes between
+      // that margin in the wireframes.
+      margin: -2em auto 2em;
+    }
+
+    .o-footer_nav-list {
+      margin-bottom: 0;
+    }
+
+    .respond-to-min( @bp-sm-min, {
+      padding-bottom: unit( (@grid_gutter-width / @base-font-size-px), em );
+      margin-bottom: unit( (@grid_gutter-width / @base-font-size-px), em );
+      border-bottom: 1px solid @gray-40;
+
+      .o-footer_top-button {
+        display: none;
+      }
+
+      .o-footer_nav-list {
+        .m-list__horizontal();
+
+        .m-list_item {
+          margin-bottom: 0;
+        }
+      }
+    } );
+
+    .respond-to-print( {
+      // !important used here to avoid being overriden by a much more specific
+      // selector that sets the display property for this element
+      // and to avoid using a selector that specific here.
+      display: none !important;
+    } );
+  }
+
+  // TODO: Refactor to use Design System Layout package.
+  &-middle-left {
+    .o-footer_list {
+      margin: 0;
+    }
+
+    /* Fix doubled border in mobile view */
+    .respond-to-max( @bp-xs-max, {
+      .o-footer_col:nth-child( n+2 ) {
+        .o-footer_list {
+          .m-list_item .m-list_link {
+            border-top-width: 0;
+          }
+        }
+      }
+    } );
+
+    .respond-to-min( @bp-sm-min, {
+      .grid_column(8);
+      border-right: 1px solid @gray-40;
+      border-left: 0;
+
+      .o-footer_col {
+        .grid_column(6);
+        border-left: 0;
+        border-right: 0;
+        padding-right: unit( (@grid_gutter-width / 2 / @base-font-size-px), em );
+      }
+    } );
+
+    .respond-to-print( {
+      // !important used here to avoid being overriden by a much more specific
+      // selector that sets the display property for this element
+      // and to avoid using a selector that specific here.
+      display: none !important;
+    } );
+  }
+
+  &-middle-right {
+    /* Fix doubled border in mobile view */
+    .respond-to-max( @bp-xs-max, {
+      .o-footer_list {
+        .m-list_item .m-list_link {
+          border-top-width: 0;
+        }
+      }
+    } );
+
+    .respond-to-min( @bp-sm-min, {
+      .grid_column(4);
+
+      .o-footer_list {
+        padding-left: @grid_gutter-width;
+        padding-right: @grid_gutter-width;
+      }
+    } );
+
+    .respond-to-print( {
+      // !important used here to avoid being overriden by a much more specific
+      // selector that sets the display property for this element
+      // and to avoid using a selector that specific here.
+      display: none !important;
+    } );
+  }
+
+  &-post {
+    margin-top: unit((@grid_gutter-width / @base-font-size-px), em);
+
+    .respond-to-min( @bp-sm-min, {
+      padding-top: unit( (@grid_gutter-width / @base-font-size-px), em );
+      border-top: 1px solid @gray-40;
+    } );
+
+    .respond-to-print( {
+      padding: 0;
+      border: none;
+      margin: 0;
+    } );
+  }
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/
+
+.o-footer .cf-icon-svg__external-link {
+  margin-left: 3px;
+}

--- a/src/components/Footer/Footer.less
+++ b/src/components/Footer/Footer.less
@@ -1,4 +1,4 @@
-@import (reference) url('@cfpb/cfpb-design-system/src/cfpb-design-system.less');
+@import (reference) '@cfpb/cfpb-design-system';
 
 // https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/css/organisms/footer.less
 

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { Icon } from '../Icon/Icon';
 import Footer from './Footer';
+import { FooterCfGov } from './FooterCfGov';
 
 const meta: Meta<typeof Footer> = {
   component: Footer,
@@ -10,6 +12,45 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const makeLink = (label: string, isExternal?: boolean): JSX.Element => (
+  <a
+    key={label}
+    href={window.location.href}
+    className={`m-list_link a-link ${isExternal ? 'a-link__icon' : ''}`}
+  >
+    <span className='a-link_text'>{label}</span>
+    {isExternal ? <Icon name='external-link' alt='External link' /> : null}
+  </a>
+);
+
+const makeSocialLink = (label: string): JSX.Element => (
+  <a key={label} href={window.location.href}>
+    <Icon name={label} withBg />
+  </a>
+);
+
+export const Example: Story = {
+  args: {
+    navLinks: [makeLink('Nav 1'), makeLink('Nav 2'), makeLink('Nav 3')],
+    socialLinks: [makeSocialLink('facebook'), makeSocialLink('youtube')],
+    linksCol1: [
+      makeLink('Col1 Link 1'),
+      makeLink('Col1 Link 2'),
+      makeLink('Col1 Link 3')
+    ],
+    linksCol2: [
+      makeLink('Col2 Link 1'),
+      makeLink('Col2 Link 2'),
+      makeLink('Col2 Link 3')
+    ],
+    linksCol3: [
+      makeLink('Col3 Link 1', true),
+      makeLink('Col3 Link 2', true),
+      makeLink('Col3 Link 3', true)
+    ]
+  }
+};
+
 export const CFGov: Story = {
-  args: {}
+  render: () => <FooterCfGov />
 };

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Footer from './Footer';
+
+const meta: Meta<typeof Footer> = {
+  component: Footer,
+  argTypes: {}
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const CFGov: Story = {
+  args: {}
+};

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,245 +1,49 @@
-import React from 'react';
-import { Icon } from '../Icon/Icon';
+import List from '../List/List';
+import { ListItemBuilder } from '../List/ListItem';
+import { BackToTop } from './BackToTop';
 import './Footer.less';
+import { FooterBanner } from './FooterBanner';
+import { FooterLinksColumn, NavLinks, SocialLinks } from './FooterLinks';
 import './SocialMedia.less';
 
-const BackToTop = (): JSX.Element => (
-  <a
-    className='a-btn a-btn__secondary o-footer_top-button'
-    data-gtm_ignore='true'
-    data-js-hook='behavior_return-to-top'
-    href='#'
-  >
-    Back to top
-    <Icon name='arrow-up' />
-  </a>
-);
-
-interface NavLinksProperties {
-  children: JSX.Element[];
+interface FooterProperties {
+  navLinks: JSX.Element[];
+  socialLinks: JSX.Element[];
+  linksCol1: JSX.Element[];
+  linksCol2: JSX.Element[];
+  linksCol3: JSX.Element[];
 }
-const NavLinks = ({ children }: NavLinksProperties): JSX.Element => (
-  <ul className='o-footer_nav-list m-list'>
-    {children.map(link => (
-      <li className='m-list_item' key={link.key}>
-        {React.cloneElement(link, {
-          className: `m-list_link ${link.props?.className ?? ''}`
-        })}
-      </li>
-    ))}
-  </ul>
-);
 
-const FooterBanner = (): JSX.Element => (
-  <div className='o-footer-post'>
-    <div
-      className='a-tagline a-tagline__large'
-      aria-label='Official website of the United States government'
-    >
-      <span className='u-usa-flag' />
-      <div className='a-tagline_text'>
-        An official website of the&nbsp;
-        <span className='u-nowrap'>United States government</span>
-      </div>
-    </div>
-  </div>
-);
-
-export default function Footer(): JSX.Element {
+/**
+ * Simply define the anchor elements for each section to compose your Footer
+ */
+export default function Footer({
+  navLinks = [],
+  socialLinks = [],
+  linksCol1 = [],
+  linksCol2 = [],
+  linksCol3 = []
+}: FooterProperties): JSX.Element {
   return (
     <footer className='o-footer' data-js-hook='state_atomic_init'>
       <div className='wrapper wrapper__match-content'>
         <div className='o-footer_pre'>
           <BackToTop />
-          <NavLinks>
-            <a className='first' href='/about-us/'>
-              About Us
-            </a>
-            <a href='/about-us/contact-us/'>Contact Us</a>
-            <a href='/about-us/careers/'>Careers</a>
-            <a href='/about-us/events/'>Events</a>
-            <a href='/enforcement/information-industry-whistleblowers/'>
-              Industry Whistleblowers
-            </a>
-            <a href='/cfpb-ombudsman/'>CFPB Ombudsman</a>
-          </NavLinks>
-          <div className='block block__flush-top block__flush-bottom block__padded-top'>
-            <div className='m-social-media m-social-media__follow'>
-              <ul className='m-list m-list__unstyled m-list__horizontal m-social-media_icons'>
-                <li className='m-list_item'>
-                  <a
-                    aria-label='Visit us on Facebook'
-                    className='m-social-media_icon'
-                    data-pretty-href='https://www.facebook.com/CFPB'
-                    href='/external-site/?ext_url=https%3A%2F%2Fwww.facebook.com%2FCFPB&amp;signature=mLDxq_fH8p2jVLrkPngPqkmwdsl_JEMSCoqZ74gLcCY'
-                  >
-                    <Icon name='facebook' withBg />
-                  </a>
-                </li>
-
-                <li className='m-list_item'>
-                  <a
-                    aria-label='Visit us on Twitter'
-                    className='m-social-media_icon'
-                    data-pretty-href='https://twitter.com/CFPB'
-                    href='/external-site/?ext_url=https%3A%2F%2Ftwitter.com%2FCFPB&amp;signature=2v_Kj1FtlY2ztSvBVUEZAzTb4Mrz1xDgzU7E4914qyo'
-                  >
-                    <Icon name='twitter' withBg />
-                  </a>
-                </li>
-
-                <li className='m-list_item'>
-                  <a
-                    aria-label='Visit us on LinkedIn'
-                    className='m-social-media_icon'
-                    data-pretty-href='https://www.linkedin.com/company/consumer-financial-protection-bureau'
-                    href='/external-site/?ext_url=https%3A%2F%2Fwww.linkedin.com%2Fcompany%2Fconsumer-financial-protection-bureau&amp;signature=cz77eS0N43ZshZvOXukyBB85_qSkkDBs7o0q5Ikf5m0'
-                  >
-                    <Icon name='linkedin' withBg />
-                  </a>
-                </li>
-
-                <li className='m-list_item'>
-                  <a
-                    aria-label='Visit us on YouTube'
-                    className='m-social-media_icon'
-                    data-pretty-href='https://www.youtube.com/user/cfpbvideo'
-                    href='/external-site/?ext_url=https%3A%2F%2Fwww.youtube.com%2Fuser%2Fcfpbvideo&amp;signature=ldBCE9dfMS_pke0Gy053F8Li0bUMA6CpBpTodqahPSA'
-                  >
-                    <Icon name='youtube' alt='Visit us on YouTube' withBg />
-                  </a>
-                </li>
-
-                <li className='m-list_item'>
-                  <a
-                    aria-label='Visit us on Flickr'
-                    className='m-social-media_icon'
-                    data-pretty-href='https://www.flickr.com/photos/cfpbphotos'
-                    href='/external-site/?ext_url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2Fcfpbphotos&amp;signature=GbqC6nvI0a2NHWTQqKaK2EOdJBMbQ9D6sv7J1TXR1oI'
-                  >
-                    <Icon name='flickr' alt='Visit us on Flickr' withBg />
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
+          <NavLinks>{navLinks}</NavLinks>
+          <SocialLinks>{socialLinks}</SocialLinks>
         </div>
 
         <div className='o-footer-middle-left'>
-          <div className='o-footer_col'>
-            <ul className='o-footer_list m-list'>
-              <li className='m-list_item'>
-                <a className='m-list_link' href='/foia-requests/'>
-                  FOIA
-                </a>
-              </li>
-              <li className='m-list_item'>
-                <a className='m-list_link' href='/privacy/'>
-                  Privacy
-                </a>
-              </li>
-              <li className='m-list_item'>
-                <a
-                  className='m-list_link'
-                  href='/privacy/website-privacy-policy/'
-                >
-                  Website Privacy Policy &amp; Legal Notices
-                </a>
-              </li>
-              <li className='m-list_item'>
-                <a className='m-list_link' href='/data/'>
-                  Data
-                </a>
-              </li>
-              <li className='m-list_item'>
-                <a className='m-list_link' href='/open-government/'>
-                  Open Government
-                </a>
-              </li>
-              <li className='m-list_item'>
-                <a
-                  className='m-list_link'
-                  href='/open-government/information-quality-guidelines/'
-                >
-                  Information Quality Guidelines
-                </a>
-              </li>
-            </ul>
-          </div>
-          <div className='o-footer_col'>
-            <ul className='o-footer_list m-list'>
-              <li className='m-list_item'>
-                <a
-                  className='m-list_link'
-                  href='/about-us/diversity-and-inclusion/'
-                >
-                  Diversity &amp; Inclusion
-                </a>
-              </li>
-
-              <li className='m-list_item'>
-                <a
-                  className='m-list_link'
-                  href='/administrative-adjudication-proceedings/'
-                >
-                  Administrative Adjudication
-                </a>
-              </li>
-
-              <li className='m-list_item'>
-                <a className='m-list_link' href='/plain-writing/'>
-                  Plain Writing
-                </a>
-              </li>
-              <li className='m-list_item'>
-                <a className='m-list_link' href='/accessibility/'>
-                  Accessibility
-                </a>
-              </li>
-              <li className='m-list_item'>
-                <a className='m-list_link' href='/office-civil-rights/'>
-                  Office of Civil Rights
-                </a>
-              </li>
-              <li className='m-list_item'>
-                <a
-                  className='m-list_link'
-                  href='/office-civil-rights/no-fear-act-cummings-act/'
-                >
-                  No FEAR Act &amp; Cummings Act
-                </a>
-              </li>
-
-              <li className='m-list_item'>
-                <a className='m-list_link' href='/tribal/'>
-                  Tribal
-                </a>
-              </li>
-            </ul>
-          </div>
+          <FooterLinksColumn>{linksCol1}</FooterLinksColumn>
+          <FooterLinksColumn>{linksCol2}</FooterLinksColumn>
         </div>
 
         <div className='o-footer-middle-right'>
-          <ul className='o-footer_list m-list'>
-            <li className='m-list_item'>
-              <a
-                className='m-list_link a-link a-link__icon'
-                href='https://usa.gov/'
-              >
-                <span className='a-link_text'>USA.gov</span>
-                <Icon name='external-link' alt='External link' />
-              </a>
-            </li>
-            <li className='m-list_item'>
-              <a
-                className='m-list_link a-link a-link__icon'
-                href='https://www.federalreserve.gov/oig/default.htm'
-              >
-                <span className='a-link_text'>Office of Inspector General</span>
-                <Icon name='external-link' alt='External link' />
-              </a>
-            </li>
-          </ul>
+          <List className='o-footer_list'>
+            <ListItemBuilder className='m-list_link'>
+              {linksCol3}
+            </ListItemBuilder>
+          </List>
         </div>
 
         <FooterBanner />

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,0 +1,249 @@
+import React from 'react';
+import { Icon } from '../Icon/Icon';
+import './Footer.less';
+import './SocialMedia.less';
+
+const BackToTop = (): JSX.Element => (
+  <a
+    className='a-btn a-btn__secondary o-footer_top-button'
+    data-gtm_ignore='true'
+    data-js-hook='behavior_return-to-top'
+    href='#'
+  >
+    Back to top
+    <Icon name='arrow-up' />
+  </a>
+);
+
+interface NavLinksProperties {
+  children: JSX.Element[];
+}
+const NavLinks = ({ children }: NavLinksProperties): JSX.Element => (
+  <ul className='o-footer_nav-list m-list'>
+    {children.map(link => (
+      <li className='m-list_item' key={link.key}>
+        {React.cloneElement(link, {
+          className: `m-list_link ${link.props?.className ?? ''}`
+        })}
+      </li>
+    ))}
+  </ul>
+);
+
+const FooterBanner = (): JSX.Element => (
+  <div className='o-footer-post'>
+    <div
+      className='a-tagline a-tagline__large'
+      aria-label='Official website of the United States government'
+    >
+      <span className='u-usa-flag' />
+      <div className='a-tagline_text'>
+        An official website of the&nbsp;
+        <span className='u-nowrap'>United States government</span>
+      </div>
+    </div>
+  </div>
+);
+
+export default function Footer(): JSX.Element {
+  return (
+    <footer className='o-footer' data-js-hook='state_atomic_init'>
+      <div className='wrapper wrapper__match-content'>
+        <div className='o-footer_pre'>
+          <BackToTop />
+          <NavLinks>
+            <a className='first' href='/about-us/'>
+              About Us
+            </a>
+            <a href='/about-us/contact-us/'>Contact Us</a>
+            <a href='/about-us/careers/'>Careers</a>
+            <a href='/about-us/events/'>Events</a>
+            <a href='/enforcement/information-industry-whistleblowers/'>
+              Industry Whistleblowers
+            </a>
+            <a href='/cfpb-ombudsman/'>CFPB Ombudsman</a>
+          </NavLinks>
+          <div className='block block__flush-top block__flush-bottom block__padded-top'>
+            <div className='m-social-media m-social-media__follow'>
+              <ul className='m-list m-list__unstyled m-list__horizontal m-social-media_icons'>
+                <li className='m-list_item'>
+                  <a
+                    aria-label='Visit us on Facebook'
+                    className='m-social-media_icon'
+                    data-pretty-href='https://www.facebook.com/CFPB'
+                    href='/external-site/?ext_url=https%3A%2F%2Fwww.facebook.com%2FCFPB&amp;signature=mLDxq_fH8p2jVLrkPngPqkmwdsl_JEMSCoqZ74gLcCY'
+                  >
+                    <Icon name='facebook' withBg />
+                  </a>
+                </li>
+
+                <li className='m-list_item'>
+                  <a
+                    aria-label='Visit us on Twitter'
+                    className='m-social-media_icon'
+                    data-pretty-href='https://twitter.com/CFPB'
+                    href='/external-site/?ext_url=https%3A%2F%2Ftwitter.com%2FCFPB&amp;signature=2v_Kj1FtlY2ztSvBVUEZAzTb4Mrz1xDgzU7E4914qyo'
+                  >
+                    <Icon name='twitter' withBg />
+                  </a>
+                </li>
+
+                <li className='m-list_item'>
+                  <a
+                    aria-label='Visit us on LinkedIn'
+                    className='m-social-media_icon'
+                    data-pretty-href='https://www.linkedin.com/company/consumer-financial-protection-bureau'
+                    href='/external-site/?ext_url=https%3A%2F%2Fwww.linkedin.com%2Fcompany%2Fconsumer-financial-protection-bureau&amp;signature=cz77eS0N43ZshZvOXukyBB85_qSkkDBs7o0q5Ikf5m0'
+                  >
+                    <Icon name='linkedin' withBg />
+                  </a>
+                </li>
+
+                <li className='m-list_item'>
+                  <a
+                    aria-label='Visit us on YouTube'
+                    className='m-social-media_icon'
+                    data-pretty-href='https://www.youtube.com/user/cfpbvideo'
+                    href='/external-site/?ext_url=https%3A%2F%2Fwww.youtube.com%2Fuser%2Fcfpbvideo&amp;signature=ldBCE9dfMS_pke0Gy053F8Li0bUMA6CpBpTodqahPSA'
+                  >
+                    <Icon name='youtube' alt='Visit us on YouTube' withBg />
+                  </a>
+                </li>
+
+                <li className='m-list_item'>
+                  <a
+                    aria-label='Visit us on Flickr'
+                    className='m-social-media_icon'
+                    data-pretty-href='https://www.flickr.com/photos/cfpbphotos'
+                    href='/external-site/?ext_url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2Fcfpbphotos&amp;signature=GbqC6nvI0a2NHWTQqKaK2EOdJBMbQ9D6sv7J1TXR1oI'
+                  >
+                    <Icon name='flickr' alt='Visit us on Flickr' withBg />
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div className='o-footer-middle-left'>
+          <div className='o-footer_col'>
+            <ul className='o-footer_list m-list'>
+              <li className='m-list_item'>
+                <a className='m-list_link' href='/foia-requests/'>
+                  FOIA
+                </a>
+              </li>
+              <li className='m-list_item'>
+                <a className='m-list_link' href='/privacy/'>
+                  Privacy
+                </a>
+              </li>
+              <li className='m-list_item'>
+                <a
+                  className='m-list_link'
+                  href='/privacy/website-privacy-policy/'
+                >
+                  Website Privacy Policy &amp; Legal Notices
+                </a>
+              </li>
+              <li className='m-list_item'>
+                <a className='m-list_link' href='/data/'>
+                  Data
+                </a>
+              </li>
+              <li className='m-list_item'>
+                <a className='m-list_link' href='/open-government/'>
+                  Open Government
+                </a>
+              </li>
+              <li className='m-list_item'>
+                <a
+                  className='m-list_link'
+                  href='/open-government/information-quality-guidelines/'
+                >
+                  Information Quality Guidelines
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div className='o-footer_col'>
+            <ul className='o-footer_list m-list'>
+              <li className='m-list_item'>
+                <a
+                  className='m-list_link'
+                  href='/about-us/diversity-and-inclusion/'
+                >
+                  Diversity &amp; Inclusion
+                </a>
+              </li>
+
+              <li className='m-list_item'>
+                <a
+                  className='m-list_link'
+                  href='/administrative-adjudication-proceedings/'
+                >
+                  Administrative Adjudication
+                </a>
+              </li>
+
+              <li className='m-list_item'>
+                <a className='m-list_link' href='/plain-writing/'>
+                  Plain Writing
+                </a>
+              </li>
+              <li className='m-list_item'>
+                <a className='m-list_link' href='/accessibility/'>
+                  Accessibility
+                </a>
+              </li>
+              <li className='m-list_item'>
+                <a className='m-list_link' href='/office-civil-rights/'>
+                  Office of Civil Rights
+                </a>
+              </li>
+              <li className='m-list_item'>
+                <a
+                  className='m-list_link'
+                  href='/office-civil-rights/no-fear-act-cummings-act/'
+                >
+                  No FEAR Act &amp; Cummings Act
+                </a>
+              </li>
+
+              <li className='m-list_item'>
+                <a className='m-list_link' href='/tribal/'>
+                  Tribal
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div className='o-footer-middle-right'>
+          <ul className='o-footer_list m-list'>
+            <li className='m-list_item'>
+              <a
+                className='m-list_link a-link a-link__icon'
+                href='https://usa.gov/'
+              >
+                <span className='a-link_text'>USA.gov</span>
+                <Icon name='external-link' alt='External link' />
+              </a>
+            </li>
+            <li className='m-list_item'>
+              <a
+                className='m-list_link a-link a-link__icon'
+                href='https://www.federalreserve.gov/oig/default.htm'
+              >
+                <span className='a-link_text'>Office of Inspector General</span>
+                <Icon name='external-link' alt='External link' />
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <FooterBanner />
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Footer/FooterBanner.tsx
+++ b/src/components/Footer/FooterBanner.tsx
@@ -1,0 +1,14 @@
+export const FooterBanner = (): JSX.Element => (
+  <div className='o-footer-post'>
+    <div
+      className='a-tagline a-tagline__large'
+      aria-label='Official website of the United States government'
+    >
+      <span className='u-usa-flag' />
+      <div className='a-tagline_text'>
+        An official website of the&nbsp;
+        <span className='u-nowrap'>United States government</span>
+      </div>
+    </div>
+  </div>
+);

--- a/src/components/Footer/FooterCfGov.tsx
+++ b/src/components/Footer/FooterCfGov.tsx
@@ -1,0 +1,141 @@
+import { Icon } from '../Icon/Icon';
+import Footer from './Footer';
+
+export const FooterCfGov = (): JSX.Element => {
+  const navLinks = [
+    <a href='/about-us/' key='about'>
+      About Us
+    </a>,
+    <a href='/about-us/contact-us/' key='contact'>
+      Contact Us
+    </a>,
+    <a href='/about-us/careers/' key='careers'>
+      Careers
+    </a>,
+    <a href='/about-us/events/' key='events'>
+      Events
+    </a>,
+    <a href='/enforcement/information-industry-whistleblowers/' key='whistle'>
+      Industry Whistleblowers
+    </a>,
+    <a href='/cfpb-ombudsman/' key='ombudsman'>
+      CFPB Ombudsman
+    </a>
+  ];
+
+  const socialLinks = [
+    <a
+      key='facebook'
+      aria-label='Visit us on Facebook'
+      data-pretty-href='https://www.facebook.com/CFPB'
+      href='/external-site/?ext_url=https%3A%2F%2Fwww.facebook.com%2FCFPB&amp;signature=mLDxq_fH8p2jVLrkPngPqkmwdsl_JEMSCoqZ74gLcCY'
+    >
+      <Icon name='facebook' withBg />
+    </a>,
+    <a
+      key='twitter'
+      aria-label='Visit us on Twitter'
+      data-pretty-href='https://twitter.com/CFPB'
+      href='/external-site/?ext_url=https%3A%2F%2Ftwitter.com%2FCFPB&amp;signature=2v_Kj1FtlY2ztSvBVUEZAzTb4Mrz1xDgzU7E4914qyo'
+    >
+      <Icon name='twitter' withBg />
+    </a>,
+    <a
+      key='linkedin'
+      aria-label='Visit us on LinkedIn'
+      data-pretty-href='https://www.linkedin.com/company/consumer-financial-protection-bureau'
+      href='/external-site/?ext_url=https%3A%2F%2Fwww.linkedin.com%2Fcompany%2Fconsumer-financial-protection-bureau&amp;signature=cz77eS0N43ZshZvOXukyBB85_qSkkDBs7o0q5Ikf5m0'
+    >
+      <Icon name='linkedin' withBg />
+    </a>,
+    <a
+      key='youtube'
+      aria-label='Visit us on YouTube'
+      data-pretty-href='https://www.youtube.com/user/cfpbvideo'
+      href='/external-site/?ext_url=https%3A%2F%2Fwww.youtube.com%2Fuser%2Fcfpbvideo&amp;signature=ldBCE9dfMS_pke0Gy053F8Li0bUMA6CpBpTodqahPSA'
+    >
+      <Icon name='youtube' alt='Visit us on YouTube' withBg />
+    </a>,
+    <a
+      key='flickr'
+      aria-label='Visit us on Flickr'
+      data-pretty-href='https://www.flickr.com/photos/cfpbphotos'
+      href='/external-site/?ext_url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2Fcfpbphotos&amp;signature=GbqC6nvI0a2NHWTQqKaK2EOdJBMbQ9D6sv7J1TXR1oI'
+    >
+      <Icon name='flickr' alt='Visit us on Flickr' withBg />
+    </a>
+  ];
+
+  const linksCol1 = [
+    <a key='foia' href='/foia-requests/'>
+      FOIA
+    </a>,
+    <a key='privacy' href='/privacy/'>
+      Privacy
+    </a>,
+    <a key='privacy-policy' href='/privacy/website-privacy-policy/'>
+      Website Privacy Policy &amp; Legal Notices
+    </a>,
+    <a key='data' href='/data/'>
+      Data
+    </a>,
+    <a key='open-government' href='/open-government/'>
+      Open Government
+    </a>,
+    <a
+      key='info-quality'
+      href='/open-government/information-quality-guidelines/'
+    >
+      Information Quality Guidelines
+    </a>
+  ];
+
+  const linksCol2 = [
+    <a key='dei' href='/about-us/diversity-and-inclusion/'>
+      Diversity &amp; Inclusion
+    </a>,
+    <a key='adjudication' href='/administrative-adjudication-proceedings/'>
+      Administrative Adjudication
+    </a>,
+    <a key='writing' href='/plain-writing/'>
+      Plain Writing
+    </a>,
+    <a key='accessibility' href='/accessibility/'>
+      Accessibility
+    </a>,
+    <a key='civ-rights' href='/office-civil-rights/'>
+      Office of Civil Rights
+    </a>,
+    <a key='no-fear' href='/office-civil-rights/no-fear-act-cummings-act/'>
+      No FEAR Act &amp; Cummings Act
+    </a>,
+    <a key='tribal' href='/tribal/'>
+      Tribal
+    </a>
+  ];
+
+  const linksCol3 = [
+    <a key='usa-gov' className='a-link a-link__icon' href='https://usa.gov/'>
+      <span className='a-link_text'>USA.gov</span>
+      <Icon name='external-link' alt='External link' />
+    </a>,
+    <a
+      key='inspector'
+      className='a-link a-link__icon'
+      href='https://www.federalreserve.gov/oig/default.htm'
+    >
+      <span className='a-link_text'>Office of Inspector General</span>
+      <Icon name='external-link' alt='External link' />
+    </a>
+  ];
+
+  return (
+    <Footer
+      navLinks={navLinks}
+      socialLinks={socialLinks}
+      linksCol1={linksCol1}
+      linksCol2={linksCol2}
+      linksCol3={linksCol3}
+    />
+  );
+};

--- a/src/components/Footer/FooterLinks.tsx
+++ b/src/components/Footer/FooterLinks.tsx
@@ -1,0 +1,58 @@
+import type { JSXElement } from '../../types/jsxElement';
+import List from '../List/List';
+import { ListItemBuilder } from '../List/ListItem';
+
+interface WrapperProperties {
+  children: JSX.Element[];
+}
+
+const isEmptyArray = (children: JSXElement[]): boolean => children.length === 0;
+
+/**
+ * Wrapper for Footer Navigation Links
+ */
+export const NavLinks = ({ children }: WrapperProperties): JSXElement => {
+  if (isEmptyArray(children)) return null;
+
+  return (
+    <List className='o-footer_nav-list'>
+      <ListItemBuilder className='m-list_link'>{children}</ListItemBuilder>
+    </List>
+  );
+};
+
+/**
+ * Wrapper for Social Navigation Links
+ */
+export const SocialLinks = ({ children }: WrapperProperties): JSXElement => {
+  if (isEmptyArray(children)) return null;
+
+  return (
+    <div className='block block__flush-top block__flush-bottom block__padded-top'>
+      <div className='m-social-media m-social-media__follow'>
+        <List className='m-social-media_icons' isUnstyled isHorizontal>
+          <ListItemBuilder className='m-social-media_icon'>
+            {children}
+          </ListItemBuilder>
+        </List>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Wrapper for column of Footer Links
+ */
+export const FooterLinksColumn = ({
+  children
+}: WrapperProperties): JSXElement => {
+  if (isEmptyArray(children)) return null;
+
+  return (
+    <div className='o-footer_col'>
+      <List className='o-footer_list'>
+        <ListItemBuilder className='m-list_link'>{children}</ListItemBuilder>
+      </List>
+    </div>
+  );
+};

--- a/src/components/Footer/SocialMedia.less
+++ b/src/components/Footer/SocialMedia.less
@@ -1,4 +1,4 @@
-@import (reference) url('@cfpb/cfpb-design-system/src/cfpb-design-system.less');
+@import (reference) '@cfpb/cfpb-design-system';
 
 // https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/css/molecules/social-media.less
 

--- a/src/components/Footer/SocialMedia.less
+++ b/src/components/Footer/SocialMedia.less
@@ -1,0 +1,102 @@
+@import (reference) url('@cfpb/cfpb-design-system/src/cfpb-design-system.less');
+
+// https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/css/molecules/social-media.less
+
+/* topdoc
+  name: Social Media
+  family: cfgov-molecules
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="m-social-media m-social-media__share">
+            <h5 class="m-social-media_heading">Share this</h5>
+            <ul class="m-list">
+                <li class="m-list_item">
+                    <a class="m-social-media_icon" href="#">
+                        {{ svg_icon('email') }}
+                        <span class="u-visually-hidden">
+                            Share by email
+                        </span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .m-social-media.m-social-media__share
+            .m-social-media_heading
+            ul.m-list
+              li.m-list_item
+                .m-social-media_icon
+                  .cf-icon-svg
+                  span.u-visually-hidden
+      notes:
+        - "m-social-media__follow modifier is identical
+           but does not include the heading."
+  tags:
+    - cfgov-molecules
+*/
+
+.m-social-media {
+  display: inline-block;
+
+  // This could be wrapped in the `m-social-media__share` modifier,
+  // but it's ok on its own too.
+  &_heading {
+    .heading-5();
+    display: inline-block;
+    // 0.25em subtracted to compensate for inline spacing
+    padding-right: unit((@grid_gutter-width / @font-size - 0.25em), em);
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+
+  .m-list {
+    display: inline-block;
+    vertical-align: middle;
+
+    .m-list_item {
+      // 0.25em subtracted to compensate for inline spacing
+      margin-right: unit(
+        ((@grid_gutter-width / 2) / @base-font-size-px - 0.25em),
+        em
+      );
+      margin-bottom: 0;
+    }
+
+    .m-list_item:last-child {
+      margin-right: 0;
+    }
+  }
+
+  &_icon {
+    color: @gray-dark;
+    font-size: unit((@grid_gutter-width / @base-font-size-px), em);
+    line-height: 1;
+    .u-link__colors( @gray-dark, @pacific-80 );
+    .u-link__no-border();
+  }
+
+  &_print {
+    padding-left: unit(((@grid_gutter-width / 2) / @base-font-size-px), em);
+    border-left: 1px solid @black;
+  }
+
+  // Hide on print.
+  .respond-to-print( {
+    & {
+      display: none;
+    }
+  } );
+}
+
+.no-js .m-social-media_print {
+  display: none;
+}
+
+/* topdoc
+    name: EOF
+    eof: true
+*/

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,23 +1,25 @@
 import classnames from 'classnames';
 
 interface ListProperties {
+  children: JSX.Element | JSX.Element[];
+  className?: string;
   isHorizontal?: boolean;
   isLinks?: boolean;
   isOrdered?: boolean;
-  isUnstyled?: boolean;
   isSpaced?: boolean;
-  children: JSX.Element | JSX.Element[];
+  isUnstyled?: boolean;
 }
 
 export default function List({
   children,
+  className,
   isHorizontal,
   isLinks = false,
   isOrdered,
   isSpaced,
   isUnstyled
 }: ListProperties): JSX.Element {
-  const cnames = ['m-list'];
+  const cnames = [className, 'm-list'];
   if (isHorizontal) cnames.push('m-list__horizontal');
   if (isLinks) cnames.push('m-list__links');
   if (isSpaced) cnames.push('m-list__spaced');

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 interface ListItemProperties {
   children: JSX.Element | string;
 }
@@ -6,4 +8,49 @@ export default function ListItem({
   children
 }: ListItemProperties): JSX.Element {
   return <li className='m-list_item'>{children}</li>;
+}
+
+interface ListItemBuilderProperties {
+  children: JSX.Element[];
+  className?: string;
+}
+/**
+ * A utility component that wraps each child element in an <li>,
+ * while adding the provided `className` prop to the newly wrapped element.
+ *
+ * Example:
+ * <ListItemBuilder className='m-list_link'>
+ *   <a className='selected' href='/home' key='home'>Homepage</a>
+ *   <a href='/away' key='away'>Other page</a>
+ * </ListItemBuilder>
+ *
+ * Example Output:
+ * <>
+ *   <li class='m-list_item key='home'>
+ *    <a class='m-list_link selected' href='/home'>Homepage</a>
+ *   </li>
+ *   <li class='m-list_item key='away'>
+ *    <a class='m-list_link' href='/away'>Other page</a>
+ *   </li>
+ * </>
+ *
+ * @param children Elements to be wrapped in <li>
+ * @param className Class name to be applied each of the `children` elements (not the <li>)
+ * @returns Single nestable JSX element
+ */
+export function ListItemBuilder({
+  children,
+  className = ''
+}: ListItemBuilderProperties): JSX.Element {
+  return (
+    <>
+      {children.map((element: JSX.Element) => (
+        <ListItem key={element.key}>
+          {React.cloneElement(element, {
+            className: `${className} ${element.props?.className ?? ''}`
+          })}
+        </ListItem>
+      ))}
+    </>
+  );
 }


### PR DESCRIPTION
Closes #58 

## Changes

- Distills the CFPB Footer organism so that users simply define the links for each section
- Pulls in styles from CF.gov (social-media.less, footer.less)


## How to test this PR

1. Check out the netlify deployment

## Screenshots
| label | shot|
|---|---|
|CF.gov|![Screen Shot 2023-06-23 at 1 11 24 PM](https://github.com/cfpb/design-stories/assets/2592907/37df27dd-4206-4aba-9251-a9e99f8b0d99)|
|Example|![Screen Shot 2023-06-23 at 1 11 06 PM](https://github.com/cfpb/design-stories/assets/2592907/35d2bddd-123d-4edf-97f7-e9bb6e577fef)|
