### PR TITLE
Re-enable Storybook automatic documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @contolini @meissadia @the-raft-oar
+* @contolini @meissadia

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,6 +7,10 @@ module.exports = {
     '@storybook/addon-interactions',
     '@storybook/addon-a11y'
   ],
+  docs: {
+    autodocs: true,
+    defaultName: 'Overview'
+  },
   framework: {
     name: '@storybook/react-vite',
     options: {}


### PR DESCRIPTION
Re-enables Storybook autodocs but allows manual MDX overrides if desired for specific components.

See https://github.com/cfpb/design-stories/issues/92

## How to test this PR

1. Verify the netlify build has an `Overview` section for every component.
