### PR TITLE
74 dropdown redesign

### DIFF
--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -5,6 +5,6 @@ interface DividerProperties {
 export default function Divider({
   className = '',
   ...properties
-}: DividerProperties): JSX.Element {
+}: DividerProperties & React.HTMLProps<HTMLDivElement>): JSX.Element {
   return <div className={`content_line ${className}`} {...properties} />;
 }

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -2,6 +2,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { Button } from '../Button/Button';
+import type { SelectOption } from './Dropdown';
 import { Dropdown } from './Dropdown';
 import { MockOptions } from './utils';
 
@@ -55,14 +56,7 @@ export const Disabled: Story = {
 export const MultiSelect: Story = {
   args: {
     ...DefaultDropdown.args,
-    options: [
-      ...MockOptions,
-      {
-        value: 'long',
-        label:
-          'Multiselect options can also contain long words that will be wrapped like supercalifragilisticexpialidocious'
-      }
-    ],
+    options: [...MockOptions],
     id: 'multi',
     isMulti: true,
     label: 'Multi-select'
@@ -72,14 +66,7 @@ export const MultiSelect: Story = {
 export const MultiSelectWithDefaultValue: Story = {
   args: {
     ...DefaultDropdown.args,
-    options: [
-      ...MockOptions,
-      {
-        value: 'long',
-        label:
-          'Multiselect options can also contain long words that will be wrapped like supercalifragilisticexpialidocious'
-      }
-    ],
+    options: [...MockOptions],
     defaultValue: [MockOptions[0]],
     id: 'multi',
     isMulti: true,
@@ -87,17 +74,23 @@ export const MultiSelectWithDefaultValue: Story = {
   }
 };
 
+export const MultiSelectWithCheckboxes: Story = {
+  args: {
+    ...DefaultDropdown.args,
+    options: [...MockOptions],
+    defaultValue: [MockOptions[0]],
+    id: 'multi',
+    isMulti: true,
+    label: 'Multi-select',
+    pillAlign: 'bottom',
+    withCheckbox: true
+  }
+};
+
 export const MultiSelectWithPillsAlignedBottom: Story = {
   args: {
     ...DefaultDropdown.args,
-    options: [
-      ...MockOptions,
-      {
-        value: 'long',
-        label:
-          'Multiselect options can also contain long words that will be wrapped like supercalifragilisticexpialidocious'
-      }
-    ],
+    options: [...MockOptions],
     defaultValue: [MockOptions[0]],
     id: 'multi',
     isMulti: true,
@@ -106,14 +99,48 @@ export const MultiSelectWithPillsAlignedBottom: Story = {
   }
 };
 
-const ControlledDropdown = arguments_ => {
-  const [selected, setSelected] = useState([arguments_.options[0]]);
+export const MultiSelectWithoutPills: Story = {
+  args: {
+    ...DefaultDropdown.args,
+    options: [...MockOptions],
+    defaultValue: [MockOptions[0]],
+    id: 'multi',
+    isMulti: true,
+    label: 'Multi-select',
+    pillAlign: 'hide',
+    withCheckbox: true
+  }
+};
+
+export const MultiSelectWithoutClearAllButton: Story = {
+  args: {
+    ...DefaultDropdown.args,
+    options: [...MockOptions],
+    defaultValue: [MockOptions[0]],
+    id: 'multi',
+    isMulti: true,
+    label: 'Multi-select',
+    pillAlign: 'bottom',
+    withCheckbox: true,
+    showClearAllSelectedButton: false
+  }
+};
+
+interface ControlledArguments {
+  options: SelectOption[];
+}
+const ControlledDropdown = ({
+  options,
+  ...arguments_
+}: ControlledArguments): JSX.Element => {
+  const [selected, setSelected] = useState([options[0]]);
+
   return (
     <>
       <div className='m-btn-group u-mb30'>
         <Button
           label='Add all options'
-          onClick={(): void => setSelected([...arguments_.options])}
+          onClick={(): void => setSelected([...options])}
         />
         <Button
           label='Clear all options'
@@ -122,9 +149,12 @@ const ControlledDropdown = arguments_ => {
         />
       </div>
       <Dropdown
-        {...arguments_}
+        id='controlled-dropdown'
+        options={options}
+        showClearAllSelectedButton={false}
         onSelect={(newValue): void => setSelected(newValue)}
         value={selected}
+        {...arguments_}
       />
     </>
   );
@@ -134,14 +164,7 @@ export const AsAControlledComponent: Story = {
   render: arguments_ => <ControlledDropdown {...arguments_} />,
   args: {
     ...DefaultDropdown.args,
-    options: [
-      ...MockOptions,
-      {
-        value: 'long',
-        label:
-          'Multiselect options can also contain long words that will be wrapped like supercalifragilisticexpialidocious'
-      }
-    ],
+    options: [...MockOptions],
     defaultValue: [MockOptions[0]],
     id: 'multi',
     isMulti: true,

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -92,7 +92,7 @@ describe('Default Dropdown', () => {
           options: MockOptions,
           onSelect,
           placeholder,
-          defaultValue: MockOptions.at(-1)
+          defaultValue: MockOptions.at(2)
         }}
       />
     );
@@ -136,7 +136,7 @@ describe('Multi-select Dropdown', () => {
     });
 
     const pills = screen.queryAllByRole('listitem');
-    expect(pills.length).toBe(1);
+    expect(pills.length).toBe(2);
 
     const selectedOption = pills[0];
     expect(selectedOption).toHaveClass('pill');
@@ -167,7 +167,7 @@ describe('Multi-select Dropdown', () => {
     // Verify pill displayed
     expect(screen.getByText(optionLabel)).toBeInTheDocument();
     const afterSelection = screen.queryAllByRole('listitem');
-    expect(afterSelection.length).toBe(1);
+    expect(afterSelection.length).toBe(2);
     expect(afterSelection[0]).toHaveClass('pill');
     expect(afterSelection[0]).toHaveTextContent(optionLabel);
 
@@ -190,7 +190,8 @@ describe('Multi-select Dropdown', () => {
 
     // Verify pills displayed
     const afterSelection = screen.queryAllByRole('listitem');
-    expect(afterSelection.length).toBe(3);
+    // All options + Clear All button
+    expect(afterSelection.length).toBe(5);
     expect(afterSelection[2]).toHaveClass('pill');
     expect(afterSelection[2]).toHaveTextContent(optionLabel);
 
@@ -202,7 +203,7 @@ describe('Multi-select Dropdown', () => {
 
     // Verify correct option's pill was removed, while others remain
     const afterDelete = screen.queryAllByRole('listitem');
-    expect(afterDelete.length).toBe(2);
+    expect(afterDelete.length).toBe(4);
     expect(afterDelete[0]).toHaveTextContent('Option B');
     expect(afterDelete[1]).toHaveTextContent('Option C');
   });

--- a/src/components/Dropdown/DropdownInputWithCheckbox.css
+++ b/src/components/Dropdown/DropdownInputWithCheckbox.css
@@ -1,0 +1,3 @@
+.OptionWithCheckbox .checkbox {
+  margin-right: 5px;
+}

--- a/src/components/Dropdown/DropdownInputWithCheckbox.tsx
+++ b/src/components/Dropdown/DropdownInputWithCheckbox.tsx
@@ -1,0 +1,70 @@
+import type { ReactElement, ReactNode } from 'react';
+import { useState } from 'react';
+import { components } from 'react-select';
+import './DropdownInputWithCheckbox.css';
+
+interface TypeCheckboxInput {
+  children: ReactNode;
+  getStyles: any; // TODO: figure out type - GetStyles<Option, IsMulti, Group>?
+  innerProps: JSX.IntrinsicElements['div'];
+  isDisabled: boolean;
+  isFocused: boolean;
+  isSelected: boolean;
+}
+const CheckboxInputOption = ({
+  children,
+  getStyles,
+  innerProps,
+  isDisabled,
+  isFocused,
+  isSelected,
+  ...rest
+}: TypeCheckboxInput): ReactElement => {
+  const [isActive, setIsActive] = useState(false);
+  const onMouseDown = (): void => setIsActive(true);
+  const onMouseUp = (): void => setIsActive(false);
+  const onMouseLeave = (): void => setIsActive(false);
+
+  // styles
+  let bg = 'transparent';
+  if (isFocused) bg = '#eee';
+  if (isActive) bg = '#B2D4FF';
+
+  const style = {
+    alignItems: 'center',
+    backgroundColor: bg,
+    color: 'inherit',
+    display: 'flex '
+  };
+
+  // prop assignment
+  const properties = {
+    ...innerProps,
+    onMouseDown,
+    onMouseUp,
+    onMouseLeave,
+    style
+  };
+
+  return (
+    <components.Option
+      className='OptionWithCheckbox'
+      getStyles={getStyles}
+      innerProps={properties}
+      isDisabled={isDisabled}
+      isFocused={isFocused}
+      isSelected={isSelected}
+      {...rest}
+    >
+      <input
+        className='checkbox'
+        type='checkbox'
+        checked={isSelected}
+        readOnly
+      />
+      {children}
+    </components.Option>
+  );
+};
+
+export default CheckboxInputOption;

--- a/src/components/Dropdown/DropdownPills.less
+++ b/src/components/Dropdown/DropdownPills.less
@@ -1,12 +1,44 @@
 @import (reference) '/src/assets/styles/_shared.less';
 
+.o-multiselect_choices figcaption,
+.o-multiselect_choices ul {
+  display: inline-block;
+  vertical-align: top;
+  margin-top: 1em;
+}
+
+.o-multiselect_choices .pill {
+  display: block;
+
+  .a-label {
+    border: 1px solid @teal;
+    background-color: @teal-20;
+    color: black;
+    padding: 2px 25px 2px 10px;
+
+    .cf-icon-svg {
+      fill: @black;
+    }
+  }
+
+  &.clear-selected .a-btn {
+    background-color: @red-dark;
+    color: @white;
+    border-radius: 4px;
+    padding: 5px 8px;
+    margin-top: inherit;
+    display: block;
+    margin-top: 20px;
+  }
+}
+
 .o-multiselect_choices__bottom {
   li {
     margin-top: unit((8px / @base-font-size-px), em);
     margin-bottom: 0;
 
     &:first-child {
-      margin-top: unit((10px / @base-font-size-px), em);
+      margin-top: 0;
     }
   }
 }

--- a/src/components/Dropdown/DropdownPills.tsx
+++ b/src/components/Dropdown/DropdownPills.tsx
@@ -1,9 +1,9 @@
-import type { ReactEventHandler } from 'react';
+import type { ReactEventHandler, Ref } from 'react';
 import type { PropsValue } from 'react-select';
+import { Button } from '../Button/Button';
 import { Icon } from '../Icon/Icon';
 import { Label } from '../Label/Label';
 import type { SelectOption } from './Dropdown';
-
 import './DropdownPills.less';
 
 /**
@@ -59,17 +59,23 @@ export const DropdownPill = ({
 );
 
 interface DropdownPillsProperties {
-  onChange: (event: PropsValue<SelectOption>) => void;
-  selected: PropsValue<SelectOption>;
   isMulti?: boolean;
-  pillAlign?: 'top' | 'bottom';
+  labelClearAll?: string;
+  onChange: (event: PropsValue<SelectOption>) => void;
+  pillAlign?: 'bottom' | 'top';
+  selected: PropsValue<SelectOption>;
+  selectRef: Ref<any>;
+  showClearAllSelectedButton?: boolean;
 }
 
 export const DropdownPills = ({
-  selected,
   isMulti,
+  labelClearAll = 'Clear All Selected Institutions',
   onChange,
-  pillAlign = 'top'
+  pillAlign = 'top',
+  selected,
+  selectRef,
+  showClearAllSelectedButton
 }: DropdownPillsProperties): JSX.Element | null => {
   if (
     !isMulti ||
@@ -79,19 +85,31 @@ export const DropdownPills = ({
   )
     return null;
 
+  const onClearAllSelected = (): void => {
+    selectRef?.current?.clearValue();
+  };
+
   return (
-    <ul
+    <figure
       className={`o-multiselect_choices${
         pillAlign === 'bottom' ? ' o-multiselect_choices__bottom' : ''
       }`}
     >
-      {selected.map(({ value, label }: SelectOption, index: number) => (
-        <DropdownPill
-          key={value}
-          value={label}
-          onClose={onCloser(index, onChange, selected)}
-        />
-      ))}
-    </ul>
+      <figcaption>Selected:</figcaption>
+      <ul>
+        {selected.map(({ value, label }: SelectOption, index: number) => (
+          <DropdownPill
+            key={value}
+            value={label}
+            onClose={onCloser(index, onChange, selected)}
+          />
+        ))}
+        {showClearAllSelectedButton ? (
+          <li className='pill clear-selected'>
+            <Button label={labelClearAll} onClick={onClearAllSelected} />
+          </li>
+        ) : null}
+      </ul>
+    </figure>
   );
 };

--- a/src/components/Dropdown/utils.tsx
+++ b/src/components/Dropdown/utils.tsx
@@ -1,5 +1,10 @@
 export const MockOptions = [
   { value: 'value1', label: 'Option A' },
   { value: 'value2', label: 'Option B' },
-  { value: 'value3', label: 'Option C' }
+  { value: 'value3', label: 'Option C' },
+  {
+    value: 'long',
+    label:
+      'Options can also contain long words that will be wrapped like supercalifragilisticexpialidocious'
+  }
 ];

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -2,6 +2,18 @@ import classNames from 'classnames';
 import { useIconSvg } from '../../hooks/useIconSvg';
 import { numberIcons } from './iconLists';
 
+// Design System font sizes for HTML elements
+const sizeMap: Record<string, string> = {
+  h1: '34px',
+  h2: '26px',
+  h3: '22px',
+  h4: '18px',
+  h5: '14px',
+  p: '16px',
+  sub: '12px'
+};
+
+// Icons who's background is square as opposed to round
 const isSquare = new Set([
   'email',
   'facebook',
@@ -13,6 +25,7 @@ const isSquare = new Set([
   'youtube'
 ]);
 
+// Is this an number icon, based on the icon name?
 const isNumber = new Set(numberIcons);
 
 /**
@@ -40,6 +53,7 @@ interface IconProperties {
   name: string;
   alt?: string;
   withBg?: boolean;
+  size?: string;
 }
 
 /**
@@ -50,12 +64,14 @@ interface IconProperties {
  * @param name Canonical icon name
  * @param alt Alt text for image
  * @param withBg With background?
+ * @param size Match the icon size to a specified HTML element or provide a custom size. By default the icon size is determined by it's parent element's font-size.
  * @returns ReactElement | null
  */
 export const Icon = ({
   name,
   alt,
   withBg = false,
+  size = 'inherit',
   ...others
 }: IconProperties): JSX.Element | null => {
   const shapeModifier = getShapeModifier(name, withBg);
@@ -69,7 +85,8 @@ export const Icon = ({
   const iconAttributes = [
     `class="${classNames(classes)}"`,
     'role="img"',
-    `alt="${alt ?? name}"`
+    `alt="${alt ?? name}"`,
+    `style="font-size: ${sizeMap[size] || size}"`
   ].join(' ');
 
   const iconHtml = `${icon}`.replace('<svg', `<svg ${iconAttributes} `);

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -55,7 +55,8 @@ interface IconProperties {
 export const Icon = ({
   name,
   alt,
-  withBg = false
+  withBg = false,
+  ...others
 }: IconProperties): JSX.Element | null => {
   const shapeModifier = getShapeModifier(name, withBg);
   const fileName = `${name}${shapeModifier}`;
@@ -77,6 +78,7 @@ export const Icon = ({
     <span
       className='cf-icon-svg-wrapper'
       dangerouslySetInnerHTML={{ __html: iconHtml }}
+      {...others}
     />
   );
 };

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -15,9 +15,12 @@ export const Label = ({
   htmlFor,
   className,
   ...other
-}: JSX.IntrinsicElements['label'] & LabelProperties): React.ReactElement => {
+}: JSX.IntrinsicElements['label'] &
+  LabelProperties): React.ReactElement | null => {
   const styles = [...baseStyles, inline ? '' : 'a-label__heading'];
   const classes = [className, ...styles];
+
+  if (!children) return null;
 
   return (
     <label {...other} className={classnames(classes)} htmlFor={htmlFor}>

--- a/src/components/Layout/LayoutContent.tsx
+++ b/src/components/Layout/LayoutContent.tsx
@@ -12,13 +12,19 @@ export const LayoutContent = ({
   flushBottom,
   flushTopOnSmall,
   flushAllOnSmall,
-  narrow
-}: LayoutContentProperties): JSX.Element => {
+  narrow,
+  ...properties
+}: LayoutContentProperties &
+  React.HTMLAttributes<HTMLDivElement>): JSX.Element => {
   const cnames = ['content_main'];
   if (flushBottom) cnames.push('content__flush-bottom');
   if (flushTopOnSmall) cnames.push('content__flush-top-on-small-bottom');
   if (flushAllOnSmall) cnames.push('content__flush-all-on-small');
   if (narrow) cnames.push('content_main__narrow');
 
-  return <div className={classnames(cnames)}>{children}</div>;
+  return (
+    <div className={classnames(cnames)} {...properties}>
+      {children}
+    </div>
+  );
 };

--- a/src/components/Layout/LayoutSidebar.tsx
+++ b/src/components/Layout/LayoutSidebar.tsx
@@ -10,12 +10,18 @@ export const LayoutSidebar = ({
   children,
   flushBottom,
   flushTopOnSmall,
-  flushAllOnSmall
-}: LayoutSidebarProperties): JSX.Element => {
+  flushAllOnSmall,
+  ...properties
+}: LayoutSidebarProperties &
+  React.HTMLAttributes<HTMLDivElement>): JSX.Element => {
   const cnames = ['sidebar', 'content_sidebar', 'o-sidebar-content'];
   if (flushBottom) cnames.push('content__flush-bottom');
   if (flushTopOnSmall) cnames.push('content__flush-top-on-small-bottom');
   if (flushAllOnSmall) cnames.push('content__flush-all-on-small');
 
-  return <aside className={classnames(cnames)}>{children}</aside>;
+  return (
+    <aside className={classnames(cnames)} {...properties}>
+      {children}
+    </aside>
+  );
 };

--- a/src/components/Layout/LayoutWrapper.tsx
+++ b/src/components/Layout/LayoutWrapper.tsx
@@ -16,8 +16,13 @@
 interface LayoutWrapperProperties {
   children: JSX.Element | JSX.Element[] | string;
 }
+
 export const LayoutWrapper = ({
-  children
-}: LayoutWrapperProperties): JSX.Element => (
-  <div className='content_wrapper'>{children}</div>
+  children,
+  ...properties
+}: LayoutWrapperProperties &
+  React.HTMLAttributes<HTMLDivElement>): JSX.Element => (
+  <div className='content_wrapper' {...properties}>
+    {children}
+  </div>
 );

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -27,6 +27,8 @@ interface NotificationProperties {
   headingLevel?: HeadingLevel;
   children?: React.ReactNode;
   links?: NotificationLinkProperties[];
+  isVisible?: boolean;
+  showIcon?: boolean;
 }
 
 /**
@@ -40,6 +42,8 @@ interface NotificationProperties {
  * @param links Links
  * @param message Notification reason
  * @param type Type of notification
+ * @param isVisible Display/hide notification
+ * @param showIcon Display/hide notification icon
  * @returns ReactElement
  */
 export const Notification = ({
@@ -49,9 +53,13 @@ export const Notification = ({
   links,
   message,
   type = 'info',
+  isVisible = true,
+  showIcon = true,
   ...properties
 }: NotificationProperties &
-  React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
+  React.HTMLAttributes<HTMLDivElement>): React.ReactElement | null => {
+  if (!isVisible) return null;
+
   const classes = classNames(
     'm-notification',
     'm-notification__visible',
@@ -66,7 +74,7 @@ export const Notification = ({
 
   return (
     <div className={classes} data-testid='notification' {...properties}>
-      <Icon {...iconByType[type]} />
+      {showIcon ? <Icon {...iconByType[type]} /> : null}
       <div className='m-notification_content'>
         {message ? (
           <p

--- a/src/components/PageHeader/header.less
+++ b/src/components/PageHeader/header.less
@@ -66,7 +66,6 @@
 }
 @media only all and (min-width: 56.3125em) {
   .o-header_logo-img {
-    margin: 0 0 1.25em 0;
     height: 50px;
   }
 }

--- a/src/components/Well/Well.tsx
+++ b/src/components/Well/Well.tsx
@@ -21,7 +21,7 @@ export default function Well({
   const callsToAction = [];
   if (links)
     for (const link of links) {
-      callsToAction.push(<ListItem>{link}</ListItem>);
+      callsToAction.push(<ListItem key={link.key}>{link}</ListItem>);
     }
 
   return (

--- a/src/components/Well/Well.tsx
+++ b/src/components/Well/Well.tsx
@@ -7,13 +7,16 @@ interface WellProperties {
   headingLevel?: HeadingLevel;
   links?: JSX.Element[];
   text: JSX.Element | string;
+  className?: string | undefined;
 }
 
 export default function Well({
   heading,
   headingLevel = 'h4',
   links,
-  text
+  text,
+  className = '',
+  ...properties
 }: WellProperties): JSX.Element {
   const callsToAction = [];
   if (links)
@@ -22,7 +25,7 @@ export default function Well({
     }
 
   return (
-    <div className='o-well'>
+    <div className={`o-well ${className}`} {...properties}>
       <p className={headingLevel}>{heading}</p>
       <p className='text'>{text}</p>
       {callsToAction.length > 0 ? <List isLinks>{callsToAction}</List> : null}

--- a/src/components/Well/Well.tsx
+++ b/src/components/Well/Well.tsx
@@ -4,9 +4,9 @@ import ListItem from '../List/ListItem';
 
 interface WellProperties {
   heading: string;
-  text: JSX.Element | string;
-  links?: JSX.Element[];
   headingLevel?: HeadingLevel;
+  links?: JSX.Element[];
+  text: JSX.Element | string;
 }
 
 export default function Well({


### PR DESCRIPTION
Updates to components to support the scenarios needed for the `Complete User Profile` page.

Closes #74 

## Changes

- Dropdown
  - Updates styling of pills
  - Allows customization of pill display location and hiding them
  - Allows display of checkbox next to dropdown options
  - Allow a 'Clear All' button to quickly clear selections
- Icon
  - Display with or without background
  - Support propagation of all supported HTML props
- Label
  - Hide if no label text provided
- Notification
  - Enable show/hide via props
  - Enable show/hide icon via props
- [New] Divider component to provide a horizontal rule
- Page Header
  - Remove unnecessary margin
- Well
  - Code cleanup

## How to test this PR

1. Open the Netlify preview
2. Visit the Dropdown, Icon, Label stories
3. See if things look sensible

## Notes

- I hate typescript
