### PR TITLE
Import the entirety of CFPB's design system

### DIFF
--- a/src/assets/styles/_shared.less
+++ b/src/assets/styles/_shared.less
@@ -1,5 +1,5 @@
 /*
  Shared styles, variables, and css overrides
 */
-@import (reference) '@cfpb/cfpb-design-system';
+@import '@cfpb/cfpb-design-system';
 @import './variables.less';


### PR DESCRIPTION
Instead of selectively importing Less rules based on the needs of individual components, import the entire Less stylesheet.

Fixes the issues we found while pairing today.

## How to test this PR

1. The PR preview should build and look normal.
