### PR TITLE
feat: Enable bypass of login/logout to allow customized user auth content

### DIFF
--- a/src/components/Navbar/Navbar.stories.tsx
+++ b/src/components/Navbar/Navbar.stories.tsx
@@ -30,3 +30,9 @@ export const LoggedOut: Story = {
     user: { loginHref: '#' }
   }
 };
+
+export const NoUser: Story = {
+  args: {
+    links: ExampleLinks
+  }
+};

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,3 +1,4 @@
+import type { JSXElement } from '~/src/types/jsxElement';
 import CFPBLogo from '../../assets/images/cfpb-logo.png';
 import Link from '../Link/Link';
 import './navbar.less';
@@ -35,11 +36,13 @@ interface UserActionsProperties {
   user?: User;
 }
 
-const UserActions = ({ user }: UserActionsProperties): JSX.Element => {
-  if (!user?.name)
+const UserActions = ({ user }: UserActionsProperties): JSXElement => {
+  if (!user) return null;
+
+  if (!user.name)
     return (
       <div className='user-actions'>
-        <Link href={user?.loginHref} className='nav-item login'>
+        <Link href={user.loginHref} className='nav-item login'>
           LOGIN
         </Link>
       </div>


### PR DESCRIPTION
Closes #109 

## Changes

Skips rendering the built-in Login / Logout links when the expected `user` object is not provided.  This allows consumers of the component to inject customized user auth content via the `links` prop.  

## Screenshots

[No User object (Storybook -> Navbar -> No User)](https://deploy-preview-110--cfpb-design-stories.netlify.app/?path=/story/components-navbar--no-user)
<img width="1198" alt="Screenshot 2023-07-31 at 2 42 26 PM" src="https://github.com/cfpb/design-stories/assets/2592907/375a9762-fc1c-4188-a611-1860af3f5058">

["User logged in" via Navbar `user` object](https://deploy-preview-110--cfpb-design-stories.netlify.app/?path=/story/components-navbar--logged-in)
<img width="1253" alt="Screenshot 2023-07-31 at 2 42 37 PM" src="https://github.com/cfpb/design-stories/assets/2592907/34778787-e216-4099-aaf7-6a9e55647546">

Custom user auth content in SBL Frontend (buttons instead of links)
<img width="1116" alt="Screenshot 2023-07-31 at 2 44 08 PM" src="https://github.com/cfpb/design-stories/assets/2592907/b17612b1-0bb7-4481-a401-9b0b10bbdf22">


