### PR TITLE
fix: [Button] destructure className from props to avoid overwriting derived classnames

### DIFF
--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -20,6 +20,7 @@ describe('<Button />', () => {
       <Button label={testLabel} className={testClass} title={testTitle} />
     );
     expect(screen.getByText(testLabel)).toBeInTheDocument();
+    expect(screen.getByText(testLabel)).toHaveClass(buttonBaseClass);
     expect(screen.getByText(testLabel)).toHaveClass(testClass);
     expect(screen.getByText(testLabel)).toHaveAttribute('title', testTitle);
   });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -45,6 +45,7 @@ export function Button({
   asLink = false,
   size = 'default',
   label,
+  className,
   ...properties
 }: ButtonProperties): JSX.Element {
   const styles = [
@@ -53,7 +54,7 @@ export function Button({
     ...sizeStyles[size]
   ];
   if (asLink) styles.push('a-btn__link');
-  if (properties.className) styles.push(properties.className);
+  if (className) styles.push(className);
 
   return (
     <button type='button' className={[...styles].join(' ')} {...properties}>


### PR DESCRIPTION
Closes #111 

- Fixes bug
- Adds test to ensure bug doesn't recur 

## How to test
- [ ] yarn vitest Button