### PR TITLE
fix: Globally restrict width of text content for components when displayed in Storybook

### DIFF
--- a/src/assets/styles/_shared.less
+++ b/src/assets/styles/_shared.less
@@ -3,3 +3,27 @@
 */
 @import '@cfpb/cfpb-design-system';
 @import './variables.less';
+
+/**
+/* Storybook components are not rendered within a CFPB layout so
+/* the DS' max-width restriction for text content is not applied. 
+/*
+/* https://github.com/cfpb/design-system/blob/main/packages/cfpb-layout/src/cfpb-layout.less#L210-L223
+/*
+/* A similar adjustment was made for the DS docs pages
+/* https://github.com/cfpb/design-system/blob/main/docs/assets/css/main.less#L109-L117
+**/
+#storybook-root,
+#storybook-docs {
+  dd,
+  dt,
+  h3,
+  h4,
+  h5,
+  h6,
+  label,
+  li,
+  p {
+    max-width: 41.875rem;
+  }
+}

--- a/src/assets/styles/_shared.less
+++ b/src/assets/styles/_shared.less
@@ -11,7 +11,7 @@
 /* https://github.com/cfpb/design-system/blob/main/packages/cfpb-layout/src/cfpb-layout.less#L210-L223
 /*
 /* A similar adjustment was made for the DS docs pages
-/* https://github.com/cfpb/design-system/blob/main/docs/assets/css/main.less#L109-L117
+/* https://github.com/cfpb/design-system/pull/1220
 **/
 #storybook-root,
 #storybook-docs {

--- a/src/components/Expandable/Expandable.stories.tsx
+++ b/src/components/Expandable/Expandable.stories.tsx
@@ -24,13 +24,13 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const Content = (
-  <>
+  <p>
     Lorem ipsum dolor sit amet, consectetur adipisicing elit. Neque ipsa
     voluptatibus soluta nobis unde quisquam temporibus magnam debitis quidem.
     Ducimus ratione corporis nesciunt earum vel est quaerat blanditiis dolore
     ipsa?&nbsp;
     <a href='/?path=/story/components-expandable--default'>Lorem link</a>
-  </>
+  </p>
 );
 
 export const Default: Story = {

--- a/src/components/Expandable/ExpandableGroup.stories.tsx
+++ b/src/components/Expandable/ExpandableGroup.stories.tsx
@@ -37,13 +37,13 @@ const Content = ({
   }`;
 
   return (
-    <div>
+    <p>
       Lorem ipsum dolor sit amet, consectetur adipisicing elit. Neque ipsa
       voluptatibus soluta nobis unde quisquam temporibus magnam debitis quidem.
       Ducimus ratione corporis nesciunt earum vel est quaerat blanditiis dolore
       ipsa?&nbsp;
       <a href={linkPath}>Lorem link</a>
-    </div>
+    </p>
   );
 };
 


### PR DESCRIPTION
Closes #120

Apply the width restriction of DS content when displayed in a DS Layout to our Storybook components

## Changes

- Adds a CSS rule to restrict text element width
- Updates Expandable.stories to use the correct child type

## Screenshots
<img width="1578" alt="Screenshot 2023-08-14 at 3 29 20 PM" src="https://github.com/cfpb/design-stories/assets/2592907/b78d8b54-2183-4be4-806f-82a890ed856d">

<img width="1580" alt="Screenshot 2023-08-14 at 3 30 09 PM" src="https://github.com/cfpb/design-stories/assets/2592907/d380c468-579a-4495-98d1-bade6bbb769e">
<img width="1564" alt="Screenshot 2023-08-14 at 3 29 32 PM" src="https://github.com/cfpb/design-stories/assets/2592907/42a1e69f-45a9-4732-9a5e-8493281fb6d0">
