### PR TITLE
fix: [Button] Apply disabled styles when button is disabled

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -6,7 +6,7 @@ const meta: Meta<typeof Button> = {
   argTypes: {
     appearance: { control: 'select' },
     size: { control: 'select' },
-    isDisabled: { control: 'boolean' }
+    disabled: { control: 'boolean' }
   }
 };
 
@@ -33,6 +33,13 @@ export const Warning: Story = {
   args: {
     ...Primary.args,
     appearance: 'warning'
+  }
+};
+
+export const Disabled: Story = {
+  args: {
+    ...Primary.args,
+    disabled: true
   }
 };
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -55,6 +55,7 @@ export function Button({
   ];
   if (asLink) styles.push('a-btn__link');
   if (className) styles.push(className);
+  if (properties.disabled) styles.push('a-btn__disabled');
 
   return (
     <button type='button' className={[...styles].join(' ')} {...properties}>


### PR DESCRIPTION
Link #142 

## Changes

- Apply disabled styles when button is disabled
- Add story for Disabled button
- Removes deprecated "isDisabled" property from Button stories

## Screenshots

<img width="318" alt="Screenshot 2023-08-15 at 3 29 36 PM" src="https://github.com/cfpb/design-stories/assets/2592907/53cb9241-3531-4620-b7ad-4d1106ed3528">

